### PR TITLE
add abbreviations csv

### DIFF
--- a/client/data/nba_abr.csv
+++ b/client/data/nba_abr.csv
@@ -1,0 +1,30 @@
+ATL,Atlanta Hawks
+BOS,Boston Celtics
+CHA,Charlotte Hornets
+CHI,Chicago Bulls
+CLE,Cleveland Cavaliers
+DAL,Dallas Mavericks
+DEN,Denver Nuggets
+DET,Detroit Pistons
+GSW,Golden State Warriors
+HOU,Houston Rockets
+IND,Indiana Pacers
+LAC,Los Angeles Clippers
+LAL,Los Angeles Lakers
+MEM,Memphis Grizzlies
+MIA,Miami Heat
+MIL,Milwaukee Bucks
+MIN,Minnesota Timberwolves
+NOH,New Orleans Pelicans
+NYK,New York Knicks
+BKN,Brooklyn Nets
+OKC,Oklahoma City Thunder
+ORL,Orlando Magic
+PHI,Philadelphia 76ers
+PHO,Phoenix Suns
+POR,Portland Trail Blazers
+SAC,Sacramento Kings
+SAS,San Antonio Spurs
+TOR,Toronto Raptors
+UTH,Utah Jazz
+WAS,Washington Wizards


### PR DESCRIPTION
csv file that contains nba team abbreviations and full names
- to be used for quick add