### PR TITLE
Add clear team button and fix search bar

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -59,6 +59,7 @@ function SearchBar(props : any) {
         inputSearchString={searchString}
         inputDebounce={0}
         autoFocus
+        styling={{height: '38px'}}
       />
     </div>
   );

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ReactSearchAutocomplete } from 'react-search-autocomplete';
 
 // The player information
@@ -48,6 +48,12 @@ function SearchBar(props : any) {
     setSearchString(result.name);
     props.setInput(result.name);
   }
+
+  useEffect( () => {
+    if (props.value === '') {
+      setSearchString('');
+    }
+  }, [props.value]);
 
   return (
     <div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -116,12 +116,13 @@ nav li {
 }
 
 #search-container {
-  margin-bottom: 30px;
+  margin-bottom: 15px;
 }
 
 #add-btn {
   background-color: #F1600D;
   border-color: #F1600D;
+  height: 38px;
 }
 
 #create-team-content {
@@ -152,7 +153,7 @@ nav li {
   justify-content: center;
 }
 
-#quick-add-btn {
+#quick-add-btn, #clear-team-btn, #creat-team-btn {
   margin-bottom: 15px;
 }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -153,8 +153,14 @@ nav li {
   justify-content: center;
 }
 
-#quick-add-btn, #clear-team-btn, #creat-team-btn {
+#quick-add-btn, #clear-team-btn, #create-team-btn {
   margin-bottom: 15px;
+}
+
+#team-btns {
+  width: 80%;
+  display: flex;
+  justify-content: space-evenly;
 }
 
 #stats-table {

--- a/client/src/pages/CreateTeam.tsx
+++ b/client/src/pages/CreateTeam.tsx
@@ -101,6 +101,7 @@ function CreateTeam(props : any) {
       warningDuplicate.hidden = true;
       warningSalary.hidden = true;
     }
+    setInput('');
   }
 
   // Updates team list

--- a/client/src/pages/CreateTeam.tsx
+++ b/client/src/pages/CreateTeam.tsx
@@ -34,6 +34,13 @@ function CreateTeam(props : any) {
   const [editing, setEditing] = useState<boolean>(false);
   const [salaryVal, setSalaryValue] = useState<number>(112400000);
 
+  // Get buttons
+  const createButton = document.getElementById('create-team-btn') as HTMLButtonElement;
+  const addButton = document.getElementById('add-btn') as HTMLButtonElement;
+  const clearButton = document.getElementById('clear-team-btn') as HTMLButtonElement;
+  const quickAddButton = document.getElementById('quick-add-btn') as HTMLButtonElement;
+  const editButton = document.getElementById('salary-btn') as HTMLButtonElement;
+
   // Base URL for Perfect Team API
   const API_URL = 'https://perfect-team-api.herokuapp.com/';
   // const API_URL = 'http://localhost:4567/';
@@ -99,11 +106,12 @@ function CreateTeam(props : any) {
   // Updates team list
   let teamList = ptNames.map((player) => {
     // Disables add button and shows create team button when the team has 12 players
-    const createButton = document.getElementById('create-team-btn') as HTMLButtonElement;
-    const addButton = document.getElementById('add-btn') as HTMLButtonElement;
-    if (createButton != null && addButton != null && ptNames.length === 12) {
+    if (createButton != null && addButton != null && clearButton != null && quickAddButton != null && ptNames.length === 12) {
       createButton.hidden = false;
       addButton.disabled = true;
+      clearButton.hidden = false;
+      quickAddButton.disabled = true;
+      editButton.disabled = true;
     }
     return (<li key={ptNames.indexOf(player)} className='player-name'>{player}</li>)
   });
@@ -173,6 +181,21 @@ function CreateTeam(props : any) {
     setSalaryValue(value);
   }, [setSalaryValue]);
 
+  // Handles clearing current team and reseting buttons
+  const clearTeamHandler = (event : React.MouseEvent) => {
+    setPTNames([]);
+    setPTRks([]);
+    setTotalSalary(0);
+    setScore(0);
+    setTax(-1);
+
+    createButton.hidden = true;
+    addButton.disabled = false;
+    clearButton.hidden = true;
+    quickAddButton.disabled = false;
+    editButton.disabled = false;
+  }
+
   // Renders create team page
   return (
     <div className='create-team-container' data-testid='create-team-container'>
@@ -218,7 +241,10 @@ function CreateTeam(props : any) {
               <ol>
                 {teamList}
               </ol>
-              <Button variant='primary' data-testid='create-team-btn' id='create-team-btn' hidden={true} onClick={submitTeamHandler}>Create Team!</Button>
+              <div id='team-btns'>
+                <Button variant='primary' data-testid='create-team-btn' id='create-team-btn' hidden={true} onClick={submitTeamHandler}>Create Team!</Button>
+                <Button variant='secondary' data-testid='clear-team-btn' id='clear-team-btn' hidden={true} onClick={clearTeamHandler}>Clear Team</Button>
+              </div>
             </Col>
             <Col sm={8} id='team'>
               <Row id='team-stats'>


### PR DESCRIPTION
- Added a clear team button that appears at the bottom of the player list when 12 players have been added
- Clicking on the Add Player button now clears the search bar
- Other buttons are disabled once the team is full