### PR TITLE
Add links for player pictures and update database table and data file

### DIFF
--- a/api/models/players.js
+++ b/api/models/players.js
@@ -4,6 +4,7 @@ const playerSchema = new mongoose.Schema({
   Rk: Number,
   Player: String,
   age: Number,
+  playerPicture: String,
   WS: String,
   salary: String,
   projSalary: String,

--- a/client/data/player.csv
+++ b/client/data/player.csv
@@ -1,606 +1,606 @@
-Rk,Player,age,proPic,WS,salary,projSalary,playerTeam
-1,Precious Achiuwa\achiupr01,22,,2.5,$45780966.00,$48070014.00,Toronto Raptors
-2,Steven Adams\adamsst01,28,,6.8,$44310840.00,$47366760.00,Memphis Grizzlies
-3,Bam Adebayo\adebaba01,24,,7.2,$44211146.00,$47063478.00,Miami Heat
-4,Santi Aldama\aldamsa01,21,,0.3,$43848000.00,$46872000.00,Memphis Grizzlies
-5,LaMarcus Aldridge\aldrila01,36,,3.1,$41180544.00,$44474988.00,Brooklyn Nets
-6,Nickeil Alexander-Walker\alexani01,23,,0.1,$40918900.00,$44119845.00,TOT
-7,Grayson Allen\allengr01,26,,4.2,$39344970.00,$42492568.00,Milwaukee Bucks
-8,Jarrett Allen\allenja01,23,,8.5,$39344970.00,$42492568.00,Cleveland Cavaliers
-9,Jose Alvarado\alvarjo01,23,,2.1,$39344900.00,$42492492.00,New Orleans Pelicans
-10,Justin Anderson\anderju01,28,,0.4,$39344900.00,$42492492.00,TOT
-11,Kyle Anderson\anderky01,28,,3.5,$37980720.00,$40600080.00,Memphis Grizzlies
-12,Giannis Antetokounmpo\antetgi01,27,,12.9,$36016200.00,$37653300.00,Milwaukee Bucks
-13,Thanasis Antetokounmpo\antetth01,29,,0.9,$36000000.00,$38482759.00,Milwaukee Bucks
-14,Carmelo Anthony\anthoca01,37,,3.6,$35500000.00,$37948276.00,Los Angeles Lakers
-15,Cole Anthony\anthoco01,21,,1.6,$35361360.00,$37980720.00,Orlando Magic
-16,OG Anunoby\anunoog01,24,,3.7,$35344828.00,$38172414.00,Toronto Raptors
-17,Ryan Arcidiacono\arcidry01,27,,0.1,$34916200.00,$36503300.00,New York Knicks
-18,Trevor Ariza\arizatr01,36,,0.2,$34502130.00,$37262300.00,Los Angeles Lakers
-19,D.J. Augustin\augusdj01,34,,0.8,$31650600.00,$33833400.00,TOT
-20,Deni Avdija\avdijde01,21,,2.4,$31610000.00,$33790000.00,Washington Wizards
-21,Joel Ayayi\ayayijo01,21,,0,$31610000.00,$33790000.00,Washington Wizards
-22,Deandre Ayton\aytonde01,23,,7.3,$31590000.00,$33930000.00,Phoenix Suns
-23,Udoka Azubuike\azubuud01,22,,0.6,$31590000.00,$33930000.00,Utah Jazz
-24,Marvin Bagley III\baglema01,22,,2,$31579390.00,$33616770.00,TOT
-25,LaMelo Ball\ballla01,20,,5.8,$31579390.00,$33616770.00,Charlotte Hornets
-26,Lonzo Ball\balllo01,24,,2.2,$31320000.00,$33640000.00,Chicago Bulls
-27,Mo Bamba\bambamo01,23,,4.5,$31300000.00,$28900000.00,Orlando Magic
-28,Desmond Bane\banede01,23,,7.2,$30864198.00,$33333333.00,Memphis Grizzlies
-29,Dalano Banton\bantoda01,22,,0.4,$30800000.00,$28400000.00,Toronto Raptors
-30,Cat Barber\barbeca01,27,,-0.1,$30510423.00,$32478837.00,Atlanta Hawks
-31,Harrison Barnes\barneha02,29,,6,$30133333.00,$32393333.00,Sacramento Kings
-32,Scottie Barnes\barnesc01,20,,6.6,$30013500.00,$31377750.00,Toronto Raptors
-33,RJ Barrett\barrerj01,21,,2.3,$29900000.00,$30100000.00,New York Knicks
-34,Will Barton\bartowi01,31,,3.2,$32405817.00,,Denver Nuggets
-35,Paris Bass\basspa01,26,,0,$29467800.00,$31650600.00,Phoenix Suns
-36,Charles Bassey\bassech01,21,,0.8,$28103550.00,$30351834.00,Philadelphia 76ers
-37,Keita Bates-Diop\bateske01,26,,1.6,$28103550.00,$30351834.00,San Antonio Spurs
-38,Nicolas Batum\batumni01,33,,3.7,$28103550.00,$30351834.00,Los Angeles Clippers
-39,Kent Bazemore\bazemke01,32,,0.1,$28103550.00,$30351834.00,Los Angeles Lakers
-40,Darius Bazley\bazleda01,21,,1.8,$27000000.00,$26500000.00,Oklahoma City Thunder
-41,Bradley Beal\bealbr01,28,,1.4,$26984128.00,$28333334.00,Washington Wizards
-42,Malik Beasley\beaslma01,25,,2.9,$34967442.00,$36596549.00,Minnesota Timberwolves
-43,Jordan Bell\belljo01,27,,0,$26000000.00,$27300000.00,Chicago Bulls
-44,DeAndre' Bembry\bembrde01,27,,2.2,$24830357.00,$26669643.00,TOT
-45,Dāvis Bertāns\bertada01,29,,0.9,$24026712.00,$25806469.00,TOT
-46,Patrick Beverley\beverpa01,33,,4.1,$24000000.00,$22000000.00,Minnesota Timberwolves
-47,Saddiq Bey\beysa01,22,,4,$23000000.00,$23500000.00,Detroit Pistons
-48,Khem Birch\birchkh01,29,,2.6,$22477273.00,$20522727.00,Toronto Raptors
-49,Goga Bitadze\bitadgo01,22,,1.9,$21700000.00,$22600000.00,Indiana Pacers
-50,Bismack Biyombo\biyombi01,29,,1.8,$21306816.00,$19602273.00,Phoenix Suns
-51,Nemanja Bjelica\bjeline01,33,,3,$21000000.00,$22680000.00,Golden State Warriors
-52,Eric Bledsoe\bledser01,32,,1.3,$20482143.00,,Los Angeles Clippers
-53,Keljin Blevins\blevike01,26,,-0.5,$20475000.00,$21450000.00,Portland Trail Blazers
-54,Bogdan Bogdanović\bogdabo01,29,,3.7,$20284091.00,$18352273.00,Atlanta Hawks
-55,Bojan Bogdanović\bogdabo02,32,,5.2,$20000000.00,$20000000.00,Utah Jazz
-56,Bol Bol\bolbo01,22,,0.1,$20000000.00,$20952381.00,Denver Nuggets
-57,Leandro Bolmaro\bolmale01,21,,0,$19800000.00,$23760000.00,Minnesota Timberwolves
-58,Isaac Bonga\bongais01,22,,0.1,$19675926.00,$21250000.00,Toronto Raptors
-59,Devin Booker\bookede01,25,,7.6,$19500000.00,,Phoenix Suns
-60,Brandon Boston Jr.\bostobr01,20,,0.4,$20168742.00,,Los Angeles Clippers
-61,Chris Boucher\bouchch01,29,,6,$18700000.00,$19550000.00,Toronto Raptors
-62,James Bouknight\bouknja01,21,,0,$18604651.00,$19534884.00,Charlotte Hornets
-63,Avery Bradley\bradlav01,31,,1.2,$18562500.00,$19937500.00,Los Angeles Lakers
-64,Tony Bradley\bradlto01,24,,1.3,$18218818.00,$19568360.00,Chicago Bulls
-65,Ignas Brazdeikis\brazdig01,23,,0.5,$18139535.00,$19046512.00,Orlando Magic
-66,Mikal Bridges\bridgmi01,25,,8.9,$18125000.00,$19375000.00,Phoenix Suns
-67,Miles Bridges\bridgmi02,23,,7.2,$18000000.00,$18000000.00,Charlotte Hornets
-68,Oshae Brissett\brissos01,23,,2.2,$18000000.00,$18000000.00,Indiana Pacers
-69,Malcolm Brogdon\brogdma01,29,,2.7,$17905263.00,$21486316.00,Indiana Pacers
-70,Armoni Brooks\brookar01,23,,0.2,$17809524.00,,TOT
-71,Dillon Brooks\brookdi01,26,,1.6,$17500000.00,$18796296.00,Memphis Grizzlies
-72,Bruce Brown\brownbr01,25,,4.8,$17400000.00,$17400000.00,Brooklyn Nets
-73,Charlie Brown Jr.\brownch02,24,,0,$17357143.00,$18642857.00,TOT
-74,Chaundee Brown Jr.\brownch05,23,,0,$17142857.00,$18000000.00,TOT
-75,Greg Brown III\browngr01,20,,0.4,$17103448.00,$18206897.00,Portland Trail Blazers
-76,Jaylen Brown\brownja02,25,,5.8,$17073171.00,$17926829.00,Boston Celtics
-77,Moses Brown\brownmo01,22,,1.2,$16500000.00,$16500000.00,TOT
-78,Sterling Brown\brownst02,26,,0.8,$16409091.00,$19690909.00,Dallas Mavericks
-79,Troy Brown Jr.\browntr01,22,,1.4,$16071429.00,$17357143.00,Chicago Bulls
-80,Jalen Brunson\brunsja01,25,,7.5,$16000000.00,$16000000.00,Dallas Mavericks
-81,Thomas Bryant\bryanth01,24,,1.1,$16000000.00,$17280000.00,Washington Wizards
-82,Shaq Buchanan\buchash01,25,,0,$15690909.00,$16475454.00,Memphis Grizzlies
-83,Reggie Bullock\bullore01,30,,3.2,$15627907.00,$16372093.00,Dallas Mavericks
-84,Trey Burke\burketr01,29,,0,$15560000.00,$16902000.00,Dallas Mavericks
-85,Alec Burks\burksal01,30,,6.1,$15517242.00,$16758621.00,New York Knicks
-86,Jared Butler\butleja02,21,,0.4,$15428571.00,$16571429.00,Utah Jazz
-87,Jimmy Butler\butleji01,32,,9.2,$15384615.00,$16615385.00,Miami Heat
-88,Devontae Cacok\cacokde01,25,,0.5,$15178571.00,$16392857.00,San Antonio Spurs
-89,Kentavious Caldwell-Pope\caldwke01,28,,2.8,$15057692.00,,Washington Wizards
-90,Facundo Campazzo\campafa01,30,,2,$14391964.00,$15458035.00,Denver Nuggets
-91,Vlatko Čančar\cancavl01,24,,0.4,$14339285.00,$16607142.00,Denver Nuggets
-92,Devin Cannady\cannade01,25,,0.1,$14320988.00,$13000000.00,Orlando Magic
-93,Clint Capela\capelca01,27,,8.3,$14190000.00,,Atlanta Hawks
-94,Vernon Carey Jr.\careyve01,20,,0.1,$14000000.00,$14700000.00,TOT
-95,Jevon Carter\carteje01,26,,1.2,$14000000.00,,TOT
-96,Wendell Carter Jr.\cartewe01,22,,5,$13750000.00,$13750000.00,Orlando Magic
-97,Alex Caruso\carusal01,27,,2,$13666667.00,$14317459.00,Chicago Bulls
-98,Willie Cauley-Stein\caulewi01,28,,0.2,$13445120.00,$14520730.00,TOT
-99,Ahmad Caver\caverah01,25,,0,$13302325.00,$13906976.00,Indiana Pacers
-100,Justin Champagnie\champju01,20,,0.8,$13038862.00,$14004703.00,Toronto Raptors
-101,Zylan Cheatham\cheatzy01,26,,-0.1,$13000000.00,$13000000.00,Utah Jazz
-102,Chris Chiozza\chiozch01,26,,0,$12975471.00,,Golden State Warriors
-103,Marquese Chriss\chrisma01,24,,0.8,$12727273.00,$13745455.00,Dallas Mavericks
-104,Josh Christopher\chrisjo01,20,,0.3,$12690000.00,,Houston Rockets
-105,Gary Clark\clarkga01,27,,0.7,$12632950.00,,New Orleans Pelicans
-106,Brandon Clarke\clarkbr01,25,,6.3,$12500000.00,$11500000.00,Memphis Grizzlies
-107,Jordan Clarkson\clarkjo01,29,,3.5,$12420000.00,$13340000.00,Utah Jazz
-108,Nic Claxton\claxtni01,22,,3.5,$12200000.00,$11400000.00,Brooklyn Nets
-109,Amir Coffey\coffeam01,24,,3.8,$12195122.00,$12804878.00,Los Angeles Clippers
-110,John Collins\collijo01,24,,5.1,$12000000.00,$12600000.00,Atlanta Hawks
-111,Zach Collins\colliza01,24,,1.2,$12000000.00,$12960000.00,San Antonio Spurs
-112,Darren Collison\collida01,34,,-0.1,$12000000.00,,Los Angeles Lakers
-113,Mike Conley\conlemi01,34,,6.7,$11615328.00,$12196094.00,Utah Jazz
-114,Pat Connaughton\connapa01,29,,4.4,$11312114.00,,Milwaukee Bucks
-115,Tyler Cook\cookty01,24,,0.5,$11000000.00,$11550000.00,Chicago Bulls
-116,Sharife Cooper\coopesh01,20,,-0.2,$11000000.00,$11814815.00,Atlanta Hawks
-117,Petr Cornelie\cornepe01,26,,0,$10733400.00,$13534817.00,Denver Nuggets
-118,DeMarcus Cousins\couside01,31,,1.6,$10690909.00,$9672727.00,TOT
-119,Robert Covington\covinro01,31,,3.2,$10500000.00,,TOT
-120,Torrey Craig\craigto01,31,,2.3,$10384500.00,$11215260.00,TOT
-121,Jae Crowder\crowdja01,31,,4.3,$10384500.00,$11215260.00,Phoenix Suns
-122,Jarrett Culver\culveja01,22,,0.1,$10245480.00,$10733400.00,Memphis Grizzlies
-123,Jarron Cumberland\cumbeja01,24,,0,$10174391.00,$35700000.00,Portland Trail Blazers
-124,Cade Cunningham\cunnica01,20,,-0.5,$10050120.00,$10552800.00,Detroit Pistons
-125,Seth Curry\curryse01,31,,4.2,$10468119.00,,TOT
-126,Stephen Curry\curryst01,33,,8,$10000000.00,$10000000.00,Golden State Warriors
-127,Anthony Davis\davisan02,28,,4.5,$9937150.00,,Los Angeles Lakers
-128,Ed Davis\davised01,32,,0.5,$9742000.00,,Cleveland Cavaliers
-129,Terence Davis\daviste02,24,,0.5,$9720900.00,$10183800.00,Sacramento Kings
-130,Gabriel Deck\deckga01,26,,0.1,$9720900.00,$10183800.00,Oklahoma City Thunder
-131,Dewayne Dedmon\dedmode01,32,,3.5,$10720900.00,,Miami Heat
-132,Sam Dekker\dekkesa01,27,,0,$9720900.00,,Toronto Raptors
-133,Javin DeLaurier\delauja01,23,,0,$9720900.00,,Milwaukee Bucks
-134,DeMar DeRozan\derozde01,32,,8.8,$9603360.00,$12119440.00,Chicago Bulls
-135,Mamadi Diakite\diakima01,25,,0.3,$9536000.00,$10012800.00,Oklahoma City Thunder
-136,Cheick Diallo\diallch01,25,,0.1,$9536000.00,$10012800.00,Detroit Pistons
-137,Hamidou Diallo\diallha01,23,,2.1,$9500000.00,$10260000.00,Detroit Pistons
-138,Gorgui Dieng\dienggo01,32,,1.2,$9180560.00,$23437500.00,Atlanta Hawks
-139,Spencer Dinwiddie\dinwisp01,28,,4.1,$9166800.00,$9603360.00,TOT
-140,Donte DiVincenzo\divindo01,25,,0.7,$12213507.00,$12372008.00,TOT
-141,Luka Dončić\doncilu01,22,,7.6,$9000000.00,$9666667.00,Dallas Mavericks
-142,Luguentz Dort\dortlu01,22,,1.4,$8992200.00,$9441720.00,Oklahoma City Thunder
-143,Ayo Dosunmu\dosunay01,22,,3,$8800000.00,$9240000.00,Chicago Bulls
-144,Damyean Dotson\dotsoda01,27,,0,$8750000.00,$9398148.00,New York Knicks
-145,Devon Dotson\dotsode01,22,,0.1,$8750000.00,$9000000.00,Chicago Bulls
-146,Sekou Doumbouya\doumbse01,21,,0.1,$8730159.00,,Los Angeles Lakers
-147,Jeff Dowtin\dowtije01,24,,0,$34967442.00,$36596549.00,TOT
-148,PJ Dozier\doziepj01,25,,0.3,$8678571.00,$9321429.00,Denver Nuggets
-149,Goran Dragić\dragigo01,35,,0.4,$8623920.00,$10900635.00,TOT
-150,Andre Drummond\drumman01,28,,5.1,$8604651.00,$9034884.00,TOT
-151,Chris Duarte\duartch01,24,,0.9,$8526316.00,,Indiana Pacers
-152,David Duke Jr.\dukeda01,22,,0.3,$8437500.00,$9062500.00,Brooklyn Nets
-153,Kris Dunn\dunnkr01,27,,0.2,$8372093.00,$8790698.00,Portland Trail Blazers
-154,Kevin Durant\duranke01,33,,8.4,$8333333.00,$9000000.00,Brooklyn Nets
-155,Jaime Echenique\echenja01,24,,0,$8326471.00,$29750000.00,Washington Wizards
-156,Anthony Edwards\edwaran01,20,,4.3,$8292683.00,$8707317.00,Minnesota Timberwolves
-157,Carsen Edwards\edwarca01,23,,-0.1,$8231760.00,$8623920.00,Detroit Pistons
-158,Kessler Edwards\edwarke02,21,,0.6,$8186047.00,$8558140.00,Brooklyn Nets
-159,Rob Edwards\edwarro01,25,,0,$8137500.00,$8525000.00,Oklahoma City Thunder
-160,CJ Elleby\ellebcj01,21,,0.4,$8075160.00,$8478720.00,Portland Trail Blazers
-161,Wayne Ellington\ellinwa01,34,,1,$8050000.00,$7350000.00,Los Angeles Lakers
-162,Joel Embiid\embiijo01,27,,12,$11109327.00,$7827907.00,Philadelphia 76ers
-163,James Ennis III\ennisja01,31,,0.1,$7775400.00,$9835881.00,TOT
-164,Drew Eubanks\eubandr01,24,,3.4,$7568742.00,,TOT
-165,Tacko Fall\fallta01,26,,0.1,$7522200.00,,Cleveland Cavaliers
-166,Derrick Favors\favorde01,30,,1.4,$7518518.00,$7518518.00,Oklahoma City Thunder
-167,Bruno Fernando\fernabr01,23,,0.4,$7500000.00,$8100000.00,TOT
-168,Dorian Finney-Smith\finnedo01,28,,6.6,$7422000.00,$7775400.00,Dallas Mavericks
-169,Malik Fitts\fittsma01,24,,0.1,$7280520.00,$7644720.00,TOT
-170,Malachi Flynn\flynnma01,23,,1,$7040880.00,$8920795.00,Toronto Raptors
-171,Bryn Forbes\forbebr01,28,,1.4,$7009615.00,,TOT
-172,Aleem Ford\fordal03,24,,-0.2,$7622467.00,$333333.00,Orlando Magic
-173,Trent Forrest\forretr01,23,,1.3,$7000000.00,$7350000.00,Utah Jazz
-174,Evan Fournier\fournev01,29,,3.7,$6984127.00,$7333333.00,New York Knicks
-175,De'Aaron Fox\foxde01,24,,2.5,$6920027.00,$14150000.00,Sacramento Kings
-176,Melvin Frazier\frazime01,25,,-0.4,$6720720.00,$7040880.00,Oklahoma City Thunder
-177,Tim Frazier\fraziti01,31,,-0.2,$6593040.00,$6922440.00,TOT
-178,Enes Freedom\kanteen01,29,,1.4,$6500000.00,$6000000.00,Boston Celtics
-179,Markelle Fultz\fultzma01,23,,0.4,$6431666.00,,Orlando Magic
-180,Wenyen Gabriel\gabriwe01,24,,0.7,$6395160.00,$8109063.00,TOT
-181,Daniel Gafford\gaffoda01,23,,6,$6350000.00,$6667750.00,Washington Wizards
-182,Danilo Gallinari\gallida01,33,,3.6,$6349671.00,,Atlanta Hawks
-183,Langston Galloway\gallola01,30,,-0.2,$6175440.00,$6632880.00,TOT
-184,Darius Garland\garlada01,22,,6.3,$6104280.00,$6395160.00,Cleveland Cavaliers
-185,Marcus Garrett\garrema01,23,,0.1,$6006420.00,$6292440.00,Miami Heat
-186,Usman Garuba\garubus01,19,,0.5,$5988000.00,$6287400.00,Houston Rockets
-187,Luka Garza\garzalu01,23,,0.8,$5890000.00,$6184500.00,Detroit Pistons
-188,Rudy Gay\gayru01,35,,2.1,$5890000.00,,Utah Jazz
-189,Paul George\georgpa01,31,,1.3,$5890000.00,$6184500.00,Los Angeles Clippers
-190,Taj Gibson\gibsota01,36,,2.7,$5845978.00,,New York Knicks
-191,Josh Giddey\giddejo01,19,,0.4,$5837760.00,$7413955.00,Oklahoma City Thunder
-192,Shai Gilgeous-Alexander\gilgesh01,23,,4.6,$5573334.00,,Oklahoma City Thunder
-193,Anthony Gill\gillan01,29,,1.4,$5572680.00,$5837760.00,Washington Wizards
-194,Freddie Gillespie\gillefr01,24,,0.1,$5557725.00,$20089286.00,Orlando Magic
-195,Rudy Gobert\goberru01,29,,11.7,$5495532.00,$29750000.00,Utah Jazz
-196,Brandon Goodwin\goodwbr01,26,,0.7,$5466360.00,$5739960.00,Cleveland Cavaliers
-197,Jordan Goodwin\goodwjo01,23,,-0.1,$5421493.00,,Washington Wizards
-198,Aaron Gordon\gordoaa01,26,,5.2,$5348280.00,$6803012.00,Denver Nuggets
-199,Eric Gordon\gordoer01,33,,1.4,$5333333.00,$5728395.00,Houston Rockets
-200,Devonte' Graham\grahade01,26,,2.8,$5258735.00,$29750000.00,New Orleans Pelicans
-201,Jerami Grant\grantje01,27,,2.3,$5214584.00,,Detroit Pistons
-202,Hassani Gravett\graveha01,25,,0.3,$5200000.00,$5200000.00,Orlando Magic
-203,Danny Green\greenda02,34,,1.9,$5178572.00,,Philadelphia 76ers
-204,Draymond Green\greendr01,31,,3.6,$5170564.00,,Golden State Warriors
-205,Jalen Green\greenja05,19,,0.7,$5105160.00,$5348280.00,Houston Rockets
-206,JaMychal Green\greenja01,31,,2.7,$5007840.00,$5258280.00,Denver Nuggets
-207,Javonte Green\greenja02,28,,4.4,$5005350.00,,Chicago Bulls
-208,Jeff Green\greenje02,35,,3.9,$5000000.00,,Denver Nuggets
-209,Josh Green\greenjo02,21,,2.4,$5000000.00,,Dallas Mavericks
-210,Blake Griffin\griffbl01,32,,2.1,$5000000.00,$5250000.00,Brooklyn Nets
-211,Quentin Grimes\grimequ01,21,,1.4,$5000000.00,,New York Knicks
-212,Kyle Guy\guyky01,24,,0.1,$4990000.00,,Miami Heat
-213,Rui Hachimura\hachiru01,23,,1.4,$4916160.00,$6263188.00,Washington Wizards
-214,Tyrese Haliburton\halibty01,21,,7,$4910000.00,$5155500.00,TOT
-215,Tyler Hall\hallty01,24,,0,$7310000.00,$5155000.00,New York Knicks
-216,R.J. Hampton\hamptrj01,20,,-0.2,$4910000.00,$5155500.00,Orlando Magic
-217,Tim Hardaway Jr.\hardati02,29,,2,$4878049.00,$5121951.00,Dallas Mavericks
-218,James Harden\hardeja01,32,,7.6,$2641691.00,,TOT
-219,Maurice Harkless\harklma01,28,,0.5,$4736102.00,,Sacramento Kings
-220,Jared Harper\harpeja01,24,,0.4,$4692840.00,$4916160.00,New Orleans Pelicans
-221,Montrezl Harrell\harremo01,28,,7.3,$4675830.00,,TOT
-222,Gary Harris\harriga01,27,,2.2,$4670160.00,$5954454.00,Orlando Magic
-223,Joe Harris\harrijo01,30,,0.5,$4650000.00,$5022000.00,Brooklyn Nets
-224,Tobias Harris\harrito02,29,,5.6,$4629630.00,$5000000.00,Philadelphia 76ers
-225,Shaquille Harrison\harrish01,28,,0,$4603320.00,$4833600.00,Brooklyn Nets
-226,Josh Hart\hartjo01,26,,4.4,$4500000.00,$4725000.00,TOT
-227,Isaiah Hartenstein\harteis01,23,,5.5,$4500000.00,$4500000.00,Los Angeles Clippers
-228,Udonis Haslem\hasleud01,41,,0.1,$4458000.00,$4670160.00,Miami Heat
-229,Sam Hauser\hausesa01,24,,0.6,$4447896.00,,Boston Celtics
-230,Jaxson Hayes\hayesja02,21,,5.1,$4437000.00,$5887899.00,New Orleans Pelicans
-231,Killian Hayes\hayeski01,20,,0.5,$4373160.00,$4591920.00,Detroit Pistons
-232,Gordon Hayward\haywago01,31,,2.8,$4347600.00,$4564980.00,Charlotte Hornets
-233,Aaron Henry\henryaa01,22,,-0.1,$4347600.00,$4564980.00,Philadelphia 76ers
-234,Juancho Hernangómez\hernaju01,26,,0.9,$4259259.00,$4600000.00,TOT
-235,Willy Hernangómez\hernawi01,27,,3.2,$4253357.00,$14508929.00,New Orleans Pelicans
-236,Tyler Herro\herroty01,22,,3.8,$4235160.00,$4437000.00,Miami Heat
-237,Buddy Hield\hieldbu01,29,,1.9,$4215120.00,$5808435.00,TOT
-238,Haywood Highsmith\highsha01,25,,0.1,$4154400.00,$4362240.00,Miami Heat
-239,George Hill\hillge01,35,,2.3,$4087904.00,,Milwaukee Bucks
-240,Malcolm Hill\hillma01,26,,0.6,$4054695.00,$9615385.00,TOT
-241,Solomon Hill\hillso01,30,,0,$4023600.00,$4215120.00,Atlanta Hawks
-242,Nate Hinton\hintona01,22,,-0.1,$4004280.00,$5722116.00,Indiana Pacers
-243,Jaylen Hoard\hoardja01,22,,0.6,$4000000.00,$12402000.00,Oklahoma City Thunder
-244,Aaron Holiday\holidaa01,25,,1.5,$4000000.00,$4000000.00,TOT
-245,Jrue Holiday\holidjr01,31,,6.9,$4000000.00,$4000000.00,Milwaukee Bucks
-246,Justin Holiday\holidju01,32,,1.4,$4000000.00,,TOT
-247,Richaun Holmes\holmeri01,28,,3.2,$3980551.00,,Sacramento Kings
-248,Rodney Hood\hoodro01,29,,0.7,$3946800.00,$4144320.00,TOT
-249,Scotty Hopson\hopsosc01,32,,0,$3940184.00,,Oklahoma City Thunder
-250,Al Horford\horfoal01,35,,7.6,$3938818.00,,Boston Celtics
-251,Talen Horton-Tucker\hortota01,21,,1.1,$3902439.00,$4097561.00,Los Angeles Lakers
-252,Danuel House Jr.\houseda01,28,,1,$3822240.00,$4004280.00,TOT
-253,Dwight Howard\howardw01,36,,3.5,$3804360.00,$5634257.00,Los Angeles Lakers
-254,Markus Howard\howarma02,22,,0.3,$3804150.00,,Denver Nuggets
-255,Kevin Huerter\huertke01,23,,2.8,$3768342.00,$9598214.00,Atlanta Hawks
-256,Jay Huff\huffja01,23,,0,$3749520.00,$3936960.00,Los Angeles Lakers
-257,Elijah Hughes\hugheel01,23,,-0.4,$3731707.00,$3918293.00,TOT
-258,Feron Hunt\huntfe01,22,,0,$3661976.00,$10700000.00,New York Knicks
-259,De'Andre Hunter\huntede01,24,,1.1,$4107149.00,$3925000.00,Atlanta Hawks
-260,Chandler Hutchison\hutchch01,25,,0,$3631200.00,$3804360.00,Phoenix Suns
-261,Bones Hyland\hylanbo01,21,,2.4,$3562080.00,$3740160.00,Denver Nuggets
-262,Serge Ibaka\ibakase01,32,,2,$3500000.00,$3500000.00,TOT
-263,Andre Iguodala\iguodan01,38,,1.6,$3500000.00,$3500000.00,Golden State Warriors
-264,Joe Ingles\inglejo01,34,,2.2,$3449400.00,$3613680.00,Utah Jazz
-265,Brandon Ingram\ingrabr01,24,,3.9,$3383640.00,$3552960.00,New Orleans Pelicans
-266,Kyrie Irving\irvinky01,29,,3.3,$3333333.00,$3492063.00,Brooklyn Nets
-267,Wes Iwundu\iwundwe01,27,,0.1,$3300000.00,$3465000.00,Atlanta Hawks
-268,Frank Jackson\jacksfr01,23,,0.7,$3277080.00,$3433320.00,Detroit Pistons
-269,Isaiah Jackson\jacksis01,20,,1.4,$3277080.00,$3433320.00,Indiana Pacers
-270,Jaren Jackson Jr.\jacksja02,22,,5.4,$3261480.00,$5009633.00,Memphis Grizzlies
-271,Josh Jackson\jacksjo02,24,,0,$3214680.00,$3375480.00,TOT
-272,Justin Jackson\jacksju01,26,,0,$12213507.00,$12372008.00,TOT
-273,Reggie Jackson\jacksre01,31,,0.4,$3169347.00,,Los Angeles Clippers
-274,LeBron James\jamesle01,37,,7.5,$3113160.00,$3261480.00,Los Angeles Lakers
-275,DeJon Jarreau\jarrede01,24,,0,$3098400.00,$4765339.00,Indiana Pacers
-276,DaQuan Jeffries\jeffrda01,24,,0,$3053760.00,$3206640.00,Memphis Grizzlies
-277,Ty Jerome\jeromty01,24,,0.5,$3000000.00,$3000000.00,Oklahoma City Thunder
-278,Isaiah Joe\joeis01,22,,0.4,$3000000.00,,Philadelphia 76ers
-279,Alize Johnson\johnsal02,25,,0.1,$3000000.00,$3150000.00,TOT
-280,B.J. Johnson\johnsbj01,26,,0.1,$2957520.00,$3098400.00,Orlando Magic
-281,Cameron Johnson\johnsca02,25,,5.6,$2901240.00,$3046200.00,Phoenix Suns
-282,David Johnson\johnsda08,20,,0,$5256308.00,$2866667.00,Toronto Raptors
-283,Jalen Johnson\johnsja05,20,,0,$2844429.00,$2844429.00,Atlanta Hawks
-284,James Johnson\johnsja01,34,,1.7,$2840160.00,$4379527.00,Brooklyn Nets
-285,Joe Johnson\johnsjo02,40,,0,$2824320.00,$2959080.00,Boston Celtics
-286,Keldon Johnson\johnske04,22,,4.9,$2770560.00,$2909160.00,San Antonio Spurs
-287,Keon Johnson\johnske07,19,,-0.5,$2726880.00,$4343920.00,TOT
-288,Stanley Johnson\johnsst04,25,,1.8,$2711280.00,$2840160.00,Los Angeles Lakers
-289,Tyler Johnson\johnsty01,29,,0.1,$2659560.00,$2792520.00,TOT
-290,Nikola Jokić\jokicni01,26,,15.2,$2641691.00,,Denver Nuggets
-291,Carlik Jones\jonesca03,24,,-0.1,$2641691.00,,TOT
-292,Damian Jones\jonesda03,26,,3.3,$2641691.00,,Sacramento Kings
-293,Derrick Jones Jr.\jonesde02,24,,2.2,$2641691.00,,Chicago Bulls
-294,Herbert Jones\joneshe01,23,,4.6,$2641691.00,,New Orleans Pelicans
-295,Jemerrio Jones\jonesje01,26,,0.1,$11109327.00,$7827907.00,Los Angeles Lakers
-296,Kai Jones\joneska01,21,,0,$2641691.00,,Charlotte Hornets
-297,Mason Jones\jonesma05,23,,0.2,$2641691.00,,Los Angeles Lakers
-298,Tre Jones\jonestr01,22,,2.9,$2641691.00,,San Antonio Spurs
-299,Tyus Jones\jonesty01,25,,5.1,$2641691.00,,Memphis Grizzlies
-300,DeAndre Jordan\jordade01,33,,1.9,$2641691.00,,TOT
-301,Cory Joseph\josepco01,30,,2.5,$2641691.00,,Detroit Pistons
-302,Georgios Kalaitzakis\kalaige01,23,,-0.1,$2641691.00,,TOT
-303,Frank Kaminsky\kaminfr01,28,,0.9,$32405817.00,,Phoenix Suns
-304,Luke Kennard\kennalu01,25,,4.5,$2641691.00,,Los Angeles Clippers
-305,Braxton Key\keybr01,24,,0.2,$2641691.00,,TOT
-306,George King\kingge03,28,,-0.1,$2641691.00,,Dallas Mavericks
-307,Louis King\kinglo02,22,,0,$2617800.00,$4306281.00,Sacramento Kings
-308,Corey Kispert\kispeco01,22,,2.3,$2602920.00,$2726880.00,Washington Wizards
-309,Maxi Kleber\klebima01,30,,3,$2553120.00,$2681040.00,Dallas Mavericks
-310,Brandon Knight\knighbr03,30,,0.1,$2513040.00,$4264629.00,Dallas Mavericks
-311,Nathan Knight\knighna01,24,,1,$2500000.00,$2625000.00,Minnesota Timberwolves
-312,Kevin Knox\knoxke01,22,,0.2,$2498760.00,$2617800.00,TOT
-313,John Konchar\konchjo01,25,,4.2,$2451120.00,$2573760.00,Memphis Grizzlies
-314,Furkan Korkmaz\korkmfu01,24,,1.2,$2412840.00,$4220057.00,Philadelphia 76ers
-315,Luke Kornet\kornelu01,26,,0.4,$2401537.00,,TOT
-316,Vit Krejci\krejcvi01,21,,0.6,$2401537.00,,Oklahoma City Thunder
-317,Arnoldas Kulboka\kulboar01,24,,0,$2401537.00,,Charlotte Hornets
-318,Jonathan Kuminga\kuminjo01,19,,3,$2401537.00,,Golden State Warriors
-319,Kyle Kuzma\kuzmaky01,26,,2,$7310000.00,$5155000.00,Washington Wizards
-320,Anthony Lamb\lamban01,24,,0,$2389641.00,,San Antonio Spurs
-321,Jeremy Lamb\lambje01,29,,1.2,$2389641.00,,TOT
-322,Jock Landale\landajo01,26,,1.5,$2389641.00,,San Antonio Spurs
-323,Romeo Langford\langfro01,22,,1.3,$2389641.00,,TOT
-324,Zach LaVine\lavinza01,26,,5.8,$2389641.00,,Chicago Bulls
-325,Jake Layman\laymaja01,27,,0.1,$5256308.00,$2866667.00,Minnesota Timberwolves
-326,Damion Lee\leeda03,29,,2.7,$2389641.00,,Golden State Warriors
-327,Saben Lee\leesa01,22,,0.9,$2353320.00,$2471160.00,Detroit Pistons
-328,Alex Len\lenal01,28,,0.9,$2353320.00,$2471160.00,Sacramento Kings
-329,Caris LeVert\leverca01,27,,2.2,$2327220.00,$2443581.00,TOT
-330,Kira Lewis Jr.\lewiski01,20,,-0.1,$2316240.00,$4171548.00,New Orleans Pelicans
-331,Scottie Lewis\lewissc01,21,,0,$2303040.00,$2412840.00,Charlotte Hornets
-332,Damian Lillard\lillada01,31,,1.7,$2259240.00,$2372160.00,Portland Trail Blazers
-333,Nassir Little\littlna01,21,,1.7,$2245400.00,,Portland Trail Blazers
-334,Isaiah Livers\liveris01,23,,0.7,$2239544.00,,Detroit Pistons
-335,Kevon Looney\looneke01,25,,6.8,$2239544.00,,Golden State Warriors
-336,Brook Lopez\lopezbr01,33,,0.7,$2239200.00,$4037278.00,Milwaukee Bucks
-337,Robin Lopez\lopezro01,33,,0.8,$2210640.00,$2316240.00,Orlando Magic
-338,Didi Louzada\louzama01,22,,0,$2197674.00,$2302326.00,TOT
-339,Kevin Love\loveke01,33,,5.7,$2168760.00,$2277000.00,Cleveland Cavaliers
-340,Kyle Lowry\lowryky01,35,,6.4,$2161440.00,$3901399.00,Miami Heat
-341,Gabriel Lundberg\lundbga01,27,,0,$2161152.00,,Phoenix Suns
-342,Timothé Luwawu-Cabarrot\luwawti01,26,,0.9,$2145720.00,$3873025.00,Atlanta Hawks
-343,Trey Lyles\lylestr01,26,,3.5,$2137440.00,$2239200.00,TOT
-344,Théo Maledon\maledth01,20,,0.3,$2130240.00,$3845083.00,Oklahoma City Thunder
-345,Sandro Mamukelashvili\mamuksa01,22,,1.1,$2096880.00,$2201400.00,Milwaukee Bucks
-346,Terance Mann\mannte01,25,,5.5,$2089448.00,,Los Angeles Clippers
-347,Tre Mann\manntr01,20,,0.1,$2089448.00,,Oklahoma City Thunder
-348,Boban Marjanović\marjabo01,33,,0.1,$2089448.00,,Dallas Mavericks
-349,Lauri Markkanen\markkla01,24,,5,$2075880.00,$2174880.00,Cleveland Cavaliers
-350,Naji Marshall\marshna01,24,,0.8,$2063280.00,$2161440.00,New Orleans Pelicans
-351,Caleb Martin\martica02,26,,4,$2048040.00,$2145720.00,Miami Heat
-352,Cody Martin\martico01,26,,3.9,$2036280.00,$2138160.00,Charlotte Hornets
-353,Kelan Martin\martike03,26,,0,$2033160.00,$2130240.00,TOT
-354,Kenyon Martin Jr.\martike04,21,,2.9,$2023800.00,$2125200.00,Houston Rockets
-355,Garrison Mathews\mathega01,25,,2.8,$2009040.00,$2109360.00,Houston Rockets
-356,Dakota Mathias\mathida01,26,,0,$2000000.00,$2000000.00,Memphis Grizzlies
-357,Wesley Matthews\matthwe02,35,,1.2,$2000000.00,$2000000.00,Milwaukee Bucks
-358,Tyrese Maxey\maxeyty01,21,,7.3,$2000000.00,,Philadelphia 76ers
-359,Skylar Mays\mayssk01,24,,0.3,$2000000.00,$1900000.00,Atlanta Hawks
-360,Miles McBride\mcbrimi01,21,,0.2,$2000000.00,$2000000.00,New York Knicks
-361,Mac McClung\mccluma01,23,,0,$1994520.00,$2094240.00,TOT
-362,CJ McCollum\mccolcj01,30,,3.6,$1977011.00,,TOT
-363,T.J. McConnell\mccontj01,29,,1.3,$1958501.00,,Indiana Pacers
-364,Jaden McDaniels\mcdanja02,21,,2.4,$1939350.00,,Minnesota Timberwolves
-365,Jalen McDaniels\mcdanja01,24,,1.7,$2541217.00,,Charlotte Hornets
-366,Doug McDermott\mcderdo01,30,,1.6,$1939350.00,,San Antonio Spurs
-367,JaVale McGee\mcgeeja01,34,,4.9,$1939350.00,,Phoenix Suns
-368,Cameron McGriff\mcgrica01,24,,0.1,$1910860.00,,Portland Trail Blazers
-369,Rodney McGruder\mcgruro01,30,,1.2,$1910860.00,,Detroit Pistons
-370,Alfonzo McKinnie\mckinal01,29,,-0.1,$1865547.00,,Chicago Bulls
-371,JaQuori McLaughlin\mclauja01,24,,0,$1846738.00,$1997718.00,Dallas Mavericks
-372,Jordan McLaughlin\mclaujo01,25,,2.3,$1802057.00,,Minnesota Timberwolves
-373,Ben McLemore\mclembe01,28,,0.8,$1802057.00,,Portland Trail Blazers
-374,De'Anthony Melton\meltode01,23,,3.7,$1789256.00,,Memphis Grizzlies
-375,Sam Merrill\merrisa01,25,,0,$1789256.00,,Memphis Grizzlies
-376,Chimezie Metu\metuch01,24,,1.5,$1789256.00,,Sacramento Kings
-377,Khris Middleton\middlkh01,30,,5.3,$1789256.00,$2036318.00,Milwaukee Bucks
-378,C.J. Miles\milescj01,34,,0,$1789256.00,$2036318.00,Boston Celtics
-379,Patty Mills\millspa02,33,,2.8,$1786878.00,$1876222.00,Brooklyn Nets
-380,Paul Millsap\millspa01,36,,0.5,$1782621.00,$1930681.00,TOT
-381,Shake Milton\miltosh01,25,,1.7,$1782621.00,$1930681.00,Philadelphia 76ers
-382,Davion Mitchell\mitchda01,23,,0.1,$1782621.00,,Sacramento Kings
-383,Donovan Mitchell\mitchdo01,25,,7.2,$1782621.00,,Utah Jazz
-384,Evan Mobley\mobleev01,20,,5.2,$76744.00,$1815677.00,Cleveland Cavaliers
-385,Malik Monk\monkma01,23,,3.6,$1782621.00,,Los Angeles Lakers
-386,Greg Monroe\monrogr01,31,,0.7,$1782621.00,,TOT
-387,Moses Moody\moodymo01,19,,1.3,$1782621.00,,Golden State Warriors
-388,Xavier Moon\moonxa01,27,,0.3,$1782621.00,$1930681.00,Los Angeles Clippers
-389,Matt Mooney\moonema01,24,,0,$1782621.00,$1930681.00,New York Knicks
-390,Ja Morant\moranja01,22,,6.7,$1782621.00,$1930681.00,Memphis Grizzlies
-391,Juwan Morgan\morgaju01,24,,0.1,$1782621.00,$1930681.00,TOT
-392,Jaylen Morris\morrija01,26,,-0.1,$1782621.00,,San Antonio Spurs
-393,Marcus Morris\morrima03,32,,2.4,$1782621.00,$1930681.00,Los Angeles Clippers
-394,Markieff Morris\morrima02,32,,0.3,$1782621.00,$1930681.00,Miami Heat
-395,Monte Morris\morrimo01,26,,5.4,$1762796.00,,Denver Nuggets
-396,Emmanuel Mudiay\mudiaem01,25,,0,$1762796.00,$1910860.00,Sacramento Kings
-397,Mychal Mulder\muldemy01,27,,-0.2,$1762769.00,,TOT
-398,Ade Murkey\murkead01,24,,0,$1729217.00,$1878720.00,Sacramento Kings
-399,Trey Murphy III\murphtr02,21,,1.9,$1729217.00,$1878720.00,New Orleans Pelicans
-400,Dejounte Murray\murrade01,25,,7.3,$1729217.00,$1878720.00,San Antonio Spurs
-401,Mike Muscala\muscami01,30,,2.1,$1729217.00,$1878720.00,Oklahoma City Thunder
-402,Svi Mykhailiuk\mykhasv01,24,,0.8,$1729217.00,,Toronto Raptors
-403,Abdel Nader\naderab01,28,,0,$3430810.00,,Phoenix Suns
-404,Larry Nance Jr.\nancela02,29,,2.3,$1701593.00,,TOT
-405,RJ Nembhard Jr.\nembhrj01,22,,0,$1720779.00,,Cleveland Cavaliers
-406,Aaron Nesmith\nesmiaa01,22,,0.4,$1701593.00,$1846738.00,Boston Celtics
-407,Raul Neto\netora01,29,,1.5,$3430810.00,,Washington Wizards
-408,Malik Newman\newmama01,24,,0,$1700000.00,$1785000.00,Cleveland Cavaliers
-409,Georges Niang\niangge01,28,,2.8,$1690507.00,,Philadelphia 76ers
-410,Daishen Nix\nixda01,19,,-0.2,$1669178.00,$1815677.00,Houston Rockets
-411,Zeke Nnaji\nnajize01,21,,1.8,$1669178.00,$1815677.00,Denver Nuggets
-412,Nerlens Noel\noelne01,27,,1.5,$1669178.00,$1815677.00,New York Knicks
-413,Jaylen Nowell\nowelja01,22,,2.8,$1669178.00,$1815677.00,Minnesota Timberwolves
-414,Frank Ntilikina\ntilila01,23,,0.9,$1669178.00,,Dallas Mavericks
-415,Jusuf Nurkić\nurkiju01,27,,3.6,$1669178.00,,Portland Trail Blazers
-416,David Nwaba\nwabada01,29,,1.3,$1517981.00,$1782621.00,Houston Rockets
-417,Jordan Nwora\nworajo01,23,,0.6,$1517981.00,$1782621.00,Milwaukee Bucks
-418,Royce O'Neale\onealro01,28,,5.5,$1517981.00,$1782621.00,Utah Jazz
-419,Semi Ojeleye\ojelese01,27,,0.2,$1517981.00,$1782621.00,TOT
-420,Chuma Okeke\okekech01,23,,2.2,$1517981.00,,Orlando Magic
-421,Josh Okogie\okogijo01,23,,0.7,$1517981.00,,Minnesota Timberwolves
-422,Onyeka Okongwu\okongon01,21,,4.2,$1517981.00,,Atlanta Hawks
-423,Isaac Okoro\okorois01,21,,4.2,$1517981.00,,Cleveland Cavaliers
-424,KZ Okpala\okpalkz01,22,,0.5,$1517981.00,$1782621.00,Miami Heat
-425,Victor Oladipo\oladivi01,29,,0.4,$1517981.00,$1782621.00,Miami Heat
-426,Cameron Oliver\oliveca01,25,,0.2,$1517981.00,,Atlanta Hawks
-427,Kelly Olynyk\olynyke01,30,,1.6,$1517981.00,$1782621.00,Detroit Pistons
-428,Eugene Omoruyi\omorueu01,24,,0.1,$1517981.00,,Dallas Mavericks
-429,Miye Oni\onimi01,24,,0,$1517981.00,$1782621.00,Utah Jazz
-430,Cedi Osman\osmande01,26,,2.9,$1517981.00,$1782621.00,Cleveland Cavaliers
-431,Daniel Oturu\oturuda01,22,,0.1,$1517981.00,$1782621.00,Toronto Raptors
-432,Kelly Oubre Jr.\oubreke01,26,,3.3,$1517981.00,$1782621.00,Charlotte Hornets
-433,Jaysean Paige\paigeja01,27,,-0.1,$1500000.00,$1563518.00,Detroit Pistons
-434,Trayvon Palmer\palmetr01,27,,0,$1500000.00,$1563518.00,Detroit Pistons
-435,Kevin Pangos\pangoke01,29,,0.1,$1489065.00,$1752638.00,Cleveland Cavaliers
-436,Jabari Parker\parkeja01,26,,0.3,$1489065.00,$1752638.00,Boston Celtics
-437,Eric Paschall\pascher01,25,,2,$1625991.00,$1752638.00,Utah Jazz
-438,Chris Paul\paulch01,36,,9.4,$1456666.00,,Phoenix Suns
-439,Cameron Payne\payneca01,27,,1.9,$2045094.00,,Phoenix Suns
-440,Elfrid Payton\paytoel01,27,,-0.2,$1366392.00,,Phoenix Suns
-441,Gary Payton II\paytoga02,29,,5.2,$4000000.00,$4000000.00,Golden State Warriors
-442,Norvel Pelle\pelleno01,28,,0,$1252127.00,,Utah Jazz
-443,Reggie Perry\perryre01,21,,0.2,$1250000.00,$1563518.00,TOT
-444,Jamorko Pickett\pickeja01,24,,0.1,$1093598.00,$1815677.00,Detroit Pistons
-445,Theo Pinson\pinsoth01,26,,0.4,$1090007.00,,Dallas Mavericks
-446,Mason Plumlee\plumlma01,31,,4.7,$1068288.00,,Charlotte Hornets
-447,Jakob Poeltl\poeltja01,26,,6.9,$1062303.00,$1563518.00,San Antonio Spurs
-448,Aleksej Pokusevski\pokusal01,20,,0.4,$1057260.00,$1563518.00,Oklahoma City Thunder
-449,Yves Pons\ponsyv01,22,,0,$1039080.00,,Memphis Grizzlies
-450,Jordan Poole\poolejo01,22,,6,$1000000.00,$1563518.00,Golden State Warriors
-451,Kevin Porter Jr.\porteke02,21,,0.8,$10720900.00,,Houston Rockets
-452,Michael Porter Jr.\portemi01,23,,-0.2,$999200.00,$999200.00,Denver Nuggets
-453,Otto Porter Jr.\porteot01,28,,4.9,$958529.00,$2193920.00,Golden State Warriors
-454,Bobby Portis\portibo01,26,,5.5,$925258.00,$1563518.00,Milwaukee Bucks
-455,Kristaps Porziņģis\porzikr01,26,,5.6,$925258.00,$1563518.00,TOT
-456,Micah Potter\pottemi01,23,,0,$925258.00,$1563518.00,Detroit Pistons
-457,Dwight Powell\poweldw01,30,,8.2,$925258.00,$1563518.00,Dallas Mavericks
-458,Myles Powell\powelmy01,24,,-0.1,$925258.00,$1563518.00,Philadelphia 76ers
-459,Norman Powell\powelno01,28,,2.8,$925258.00,$1563518.00,TOT
-460,Joshua Primo\primojo01,19,,0,$925258.00,$1563518.00,San Antonio Spurs
-461,Taurean Prince\princta02,27,,2.2,$925258.00,$1563518.00,Minnesota Timberwolves
-462,Payton Pritchard\pritcpa01,24,,3.1,$925258.00,$1563518.00,Boston Celtics
-463,Trevelin Queen\queentr01,24,,0.1,$925258.00,$1563518.00,Houston Rockets
-464,Neemia Queta\quetane01,22,,0.1,$925258.00,,Sacramento Kings
-465,Immanuel Quickley\quickim01,22,,4.2,$925258.00,,New York Knicks
-466,Jahmi'us Ramsey\ramseja01,20,,-0.1,$924730.00,,Sacramento Kings
-467,Julius Randle\randlju01,27,,3.1,$888616.00,$2351521.00,New York Knicks
-468,Austin Reaves\reaveau01,23,,2.9,$850331.00,,Los Angeles Lakers
-469,Cam Reddish\reddica01,22,,1,$785102.00,,TOT
-470,Davon Reed\reedda01,26,,1.6,$20168742.00,,Denver Nuggets
-471,Paul Reed\reedpa01,22,,1.3,$705598.00,,Philadelphia 76ers
-472,Naz Reid\reidna01,22,,3.2,$705598.00,,Minnesota Timberwolves
-473,Nick Richards\richani01,24,,1,$1290481.00,,Charlotte Hornets
-474,Josh Richardson\richajo01,28,,3.5,$666666.00,,TOT
-475,Austin Rivers\riverau01,29,,1.2,$663024.00,,Denver Nuggets
-476,Duncan Robinson\robindu01,27,,3.9,$2045094.00,,Miami Heat
-477,Justin Robinson\robinju01,24,,-0.3,$7622467.00,$333333.00,TOT
-478,Mitchell Robinson\robinmi01,23,,8.5,$1290481.00,,New York Knicks
-479,Jeremiah Robinson-Earl\robinje02,21,,1.5,$606702.00,,Oklahoma City Thunder
-480,Isaiah Roby\robyis01,23,,2.9,$2541217.00,,Oklahoma City Thunder
-481,Rajon Rondo\rondora01,35,,0.7,$11109327.00,$7827907.00,TOT
-482,Derrick Rose\rosede01,33,,1.4,$586136.00,,New York Knicks
-483,Terrence Ross\rosste01,30,,0.3,$558345.00,,Orlando Magic
-484,Terry Rozier\roziete01,27,,5.9,$527614.00,,Charlotte Hornets
-485,Ricky Rubio\rubiori01,31,,1.3,$10468119.00,,Cleveland Cavaliers
-486,D'Angelo Russell\russeda01,25,,4.4,$462629.00,,Minnesota Timberwolves
-487,Matt Ryan\ryanma01,24,,0,$4107149.00,$3925000.00,Boston Celtics
-488,Domantas Sabonis\sabondo01,25,,7.1,$377645.00,,TOT
-489,Olivier Sarr\sarrol01,22,,1,$364533.00,,Oklahoma City Thunder
-490,Tomáš Satoranský\satorto01,30,,1,$350000.00,,TOT
-491,Jordan Schakel\schakjo01,23,,-0.1,$313737.00,$1563518.00,Washington Wizards
-492,Admiral Schofield\schofad01,24,,0.3,,,Orlando Magic
-493,Dennis Schröder\schrode01,28,,2.9,$292466.00,$1563518.00,TOT
-494,Tre Scott\scotttr01,25,,0,$290967.00,$1752638.00,Cleveland Cavaliers
-495,Jay Scrubb\scrubja01,21,,0,$276039.00,,Los Angeles Clippers
-496,Wayne Selden\seldewa01,27,,0,$260561.00,$1563518.00,New York Knicks
-497,Alperen Şengün\sengual01,19,,2.1,$8558.00,,Houston Rockets
-498,Collin Sexton\sextoco01,23,,-0.1,$231062.00,$1752638.00,Cleveland Cavaliers
-499,Landry Shamet\shamela01,24,,2.6,$202068.00,,Phoenix Suns
-500,Day'Ron Sharpe\sharpda01,20,,1.2,$153488.00,,Brooklyn Nets
-501,Pascal Siakam\siakapa01,27,,8.1,$1366392.00,,Toronto Raptors
-502,Chris Silva\silvach01,25,,0.3,$1290481.00,,TOT
-503,Marko Simonovic\simonma01,22,,0,$1290481.00,,Chicago Bulls
-504,Anfernee Simons\simonan01,22,,1.9,$1290481.00,,Portland Trail Blazers
-505,Zavier Simpson\simpsza01,24,,-0.1,$924730.00,,Oklahoma City Thunder
-506,Jericho Sims\simsje01,23,,1.5,$924730.00,,New York Knicks
-507,Deividas Sirvydis\sirvyde01,21,,-0.1,$924730.00,,Detroit Pistons
-508,Javonte Smart\smartja01,22,,-0.2,$924730.00,,TOT
-509,Marcus Smart\smartma01,27,,5.6,$276039.00,,Boston Celtics
-510,Dennis Smith Jr.\smithde03,24,,0.4,$276039.00,,Portland Trail Blazers
-511,Ish Smith\smithis01,33,,0.5,,,TOT
-512,Jalen Smith\smithja04,21,,2.8,,,TOT
-513,Xavier Sneed\sneedxa01,24,,0,$55208.00,,TOT
-514,Tony Snell\snellto01,30,,0.4,$55208.00,,TOT
-515,Jaden Springer\sprinja01,19,,0,$55208.00,,Philadelphia 76ers
-516,Cassius Stanley\stanlca01,22,,0.1,$55208.00,,Detroit Pistons
-517,Nik Stauskas\stausni01,28,,0.1,$276039.00,,TOT
-518,Lance Stephenson\stephla01,31,,0.8,$924730.00,,TOT
-519,Lamar Stevens\stevela01,24,,1.6,$1625991.00,$1752638.00,Cleveland Cavaliers
-520,Isaiah Stewart\stewais01,20,,3.4,$276039.00,,Detroit Pistons
-521,Max Strus\strusma01,25,,3.6,$122741.00,$122741.00,Miami Heat
-522,Jalen Suggs\suggsja01,20,,-1.6,$888616.00,$2351521.00,Orlando Magic
-523,Craig Sword\swordcr01,28,,0.1,$888616.00,$2351521.00,Washington Wizards
-524,Keifer Sykes\sykeske01,28,,-0.5,$888616.00,$2351521.00,Indiana Pacers
-525,Jae'Sean Tate\tateja01,26,,3,$888616.00,$2351521.00,Houston Rockets
-526,Jayson Tatum\tatumja01,23,,9.6,$958529.00,$2193920.00,Boston Celtics
-527,Terry Taylor\taylote01,22,,2.4,$958529.00,$2193920.00,Indiana Pacers
-528,Garrett Temple\templga01,35,,0.8,$958529.00,$2193920.00,New Orleans Pelicans
-529,Emanuel Terry\terryem01,25,,-0.1,$2045094.00,,Phoenix Suns
-530,Tyrell Terry\terryty01,21,,0,$2045094.00,,Memphis Grizzlies
-531,Jon Teske\teskejo01,24,,0,$2045094.00,,Memphis Grizzlies
-532,Daniel Theis\theisda01,29,,1.9,$2045094.00,,TOT
-533,Brodric Thomas\thomabr01,25,,0.1,,,Boston Celtics
-534,Cam Thomas\thomaca02,20,,0.8,$586136.00,,Brooklyn Nets
-535,Isaiah Thomas\thomais02,32,,0.2,$586136.00,,TOT
-536,Matt Thomas\thomama02,27,,0.6,$606702.00,,Chicago Bulls
-537,Klay Thompson\thompkl01,31,,1.8,$606702.00,,Golden State Warriors
-538,Tristan Thompson\thomptr01,30,,1.6,$1090007.00,,TOT
-539,JT Thor\thorjt01,19,,0.3,$1090007.00,,Charlotte Hornets
-540,Matisse Thybulle\thybuma01,24,,3.7,$1068288.00,,Philadelphia 76ers
-541,Killian Tillie\tilliki02,23,,0.6,$100000.00,$1752638.00,Memphis Grizzlies
-542,Xavier Tillman Sr.\tillmxa01,23,,1.8,$1762796.00,,Memphis Grizzlies
-543,Isaiah Todd\toddis01,20,,-0.2,$1762796.00,,Washington Wizards
-544,Obi Toppin\toppiob01,23,,3.9,$1762796.00,,New York Knicks
-545,Juan Toscano-Anderson\toscaju01,28,,2,$1762796.00,,Golden State Warriors
-546,Karl-Anthony Towns\townska01,26,,10.3,$1762796.00,,Minnesota Timberwolves
-547,Gary Trent Jr.\trentga02,23,,5.6,$705598.00,,Toronto Raptors
-548,P.J. Tucker\tuckepj01,36,,5,$705598.00,,Miami Heat
-549,Rayjon Tucker\tuckera01,24,,0.4,$29814.00,$1878720.00,TOT
-550,Myles Turner\turnemy01,25,,3.1,$29814.00,$1878720.00,Indiana Pacers
-551,Jonas Valančiūnas\valanjo01,29,,7.3,,,New Orleans Pelicans
-552,Denzel Valentine\valende01,28,,0.2,$705598.00,,TOT
-553,Jarred Vanderbilt\vandeja01,22,,6,$705598.00,,Minnesota Timberwolves
-554,Fred VanVleet\vanvlfr01,27,,6.7,$29814.00,$1878720.00,Toronto Raptors
-555,Devin Vassell\vassede01,21,,3.3,,,San Antonio Spurs
-556,Gabe Vincent\vincega01,25,,2.5,$29814.00,$1878720.00,Miami Heat
-557,Nikola Vučević\vucevni01,31,,4.5,,,Chicago Bulls
-558,Dean Wade\wadede01,25,,2.3,,,Cleveland Cavaliers
-559,Franz Wagner\wagnefr01,20,,4,,,Orlando Magic
-560,Moritz Wagner\wagnemo01,24,,2.8,$1720779.00,,Orlando Magic
-561,Ish Wainright\wainris01,27,,0.6,$1720779.00,,Phoenix Suns
-562,Kemba Walker\walkeke02,31,,1.8,,,New York Knicks
-563,Lonnie Walker IV\walkelo01,23,,1.2,,,San Antonio Spurs
-564,M.J. Walker\walkemj01,23,,0,$19186.00,$1815677.00,Phoenix Suns
-565,Tyrone Wallace\wallaty01,27,,-0.1,$19186.00,$1815677.00,New Orleans Pelicans
-566,Derrick Walton\waltode01,26,,-0.2,,,Detroit Pistons
-567,Brad Wanamaker\wanambr01,32,,0,$850331.00,,TOT
-568,Duane Washington Jr.\washidu02,21,,0,,,Indiana Pacers
-569,P.J. Washington\washipj01,23,,3.4,$28779.00,$1815677.00,Charlotte Hornets
-570,YUtah Jazz Watanabe\watanyu01,27,,0.7,,,Toronto Raptors
-571,LIndiana Pacersy Waters III\waterli01,24,,0.8,$28779.00,$1815677.00,Oklahoma City Thunder
-572,Tremont Waters\watertr01,24,,0,,,TOT
-573,Trendon Watford\watfotr01,21,,1.9,,,Portland Trail Blazers
-574,Paul Watson\watsopa01,27,,0,$92857.00,$92857.00,Oklahoma City Thunder
-575,Quinndary Weatherspoon\weathqu01,25,,0.2,$290967.00,$1752638.00,Golden State Warriors
-576,Russell Westbrook\westbru01,33,,1.7,$290967.00,$1752638.00,Los Angeles Lakers
-577,Coby White\whiteco01,21,,2.4,$290967.00,$1752638.00,Chicago Bulls
-578,Derrick White\whitede01,27,,5.1,$231062.00,$1752638.00,TOT
-579,Hassan Whiteside\whiteha01,32,,5.8,$231062.00,$1752638.00,Utah Jazz
-580,Joe Wieskamp\wieskjo01,22,,0.1,$1625991.00,$1752638.00,San Antonio Spurs
-581,Aaron Wiggins\wiggiaa01,23,,1.2,$1625991.00,$1752638.00,Oklahoma City Thunder
-582,Andrew Wiggins\wiggian01,26,,5.1,$100000.00,$1752638.00,Golden State Warriors
-583,Lindell Wigginton\wiggili01,23,,0.2,,,Milwaukee Bucks
-584,Brandon Williams\willibr03,22,,-0.5,,,Portland Trail Blazers
-585,Grant Williams\willigr01,23,,5.1,$1517981.00,$1782621.00,Boston Celtics
-586,Kenrich Williams\willike04,27,,1.8,,,Oklahoma City Thunder
-587,Lou Williams\willilo02,35,,0.6,,,Atlanta Hawks
-588,Patrick Williams\willipa01,20,,0.9,$76744.00,$1815677.00,Chicago Bulls
-589,Robert Williams\williro04,24,,9.9,$58493.00,,Boston Celtics
-590,Ziaire Williams\willizi02,20,,2.2,$55208.00,,Memphis Grizzlies
-591,D.J. Wilson\wilsodj01,25,,0.4,,,Toronto Raptors
-592,Dylan Windler\windldy01,25,,0.8,,,Cleveland Cavaliers
-593,Justise Winslow\winslju01,25,,0.8,,,TOT
-594,Cassius Winston\winstca01,23,,0,,,Washington Wizards
-595,Christian Wood\woodch01,26,,4.9,,,Houston Rockets
-596,Robert Woodard II\woodaro01,22,,-0.1,,,Sacramento Kings
-597,Delon Wright\wrighde01,29,,3.6,,,Atlanta Hawks
-598,McKinley Wright IV\wrighmc01,23,,0,,,Minnesota Timberwolves
-599,Moses Wright\wrighmo01,23,,0.1,$462629.00,,TOT
-600,Gabe York\yorkga01,28,,0,,,Indiana Pacers
-601,Thaddeus Young\youngth01,33,,2.2,,,TOT
-602,Trae Young\youngtr01,23,,10,,,Atlanta Hawks
-603,Omer Yurtseven\yurtsom01,23,,2.1,,,Miami Heat
-604,Cody Zeller\zelleco01,29,,1.1,,,Portland Trail Blazers
-605,Ivica Zubac\zubaciv01,24,,7.2,,,Los Angeles Clippers
+Rk,Player,age,playerPicture,WS,salary,projSalary,playerTeam
+1,Precious Achiuwa,22,https://www.basketball-reference.com/req/202106291/images/players/achiupr01.jpg,2.5,45780966.00,48070014.00,Toronto Raptors
+2,Steven Adams,28,https://www.basketball-reference.com/req/202106291/images/players/adamsst01.jpg,6.8,44310840.00,47366760.00,Memphis Grizzlies
+3,Bam Adebayo,24,https://www.basketball-reference.com/req/202106291/images/players/adebaba01.jpg,7.2,44211146.00,47063478.00,Miami Heat
+4,Santi Aldama,21,https://www.basketball-reference.com/req/202106291/images/players/aldamsa01.jpg,0.3,43848000.00,46872000.00,Memphis Grizzlies
+5,LaMarcus Aldridge,36,https://www.basketball-reference.com/req/202106291/images/players/aldrila01.jpg,3.1,41180544.00,44474988.00,Brooklyn Nets
+6,Nickeil Alexander-Walker,23,https://www.basketball-reference.com/req/202106291/images/players/alexani01.jpg,0.1,40918900.00,44119845.00,TOT
+7,Grayson Allen,26,https://www.basketball-reference.com/req/202106291/images/players/allengr01.jpg,4.2,39344970.00,42492568.00,Milwaukee Bucks
+8,Jarrett Allen,23,https://www.basketball-reference.com/req/202106291/images/players/allenja01.jpg,8.5,39344970.00,42492568.00,Cleveland Cavaliers
+9,Jose Alvarado,23,https://www.basketball-reference.com/req/202106291/images/players/alvarjo01.jpg,2.1,39344900.00,42492492.00,New Orleans Pelicans
+10,Justin Anderson,28,https://www.basketball-reference.com/req/202106291/images/players/anderju01.jpg,0.4,39344900.00,42492492.00,TOT
+11,Kyle Anderson,28,https://www.basketball-reference.com/req/202106291/images/players/anderky01.jpg,3.5,37980720.00,40600080.00,Memphis Grizzlies
+12,Giannis Antetokounmpo,27,https://www.basketball-reference.com/req/202106291/images/players/antetgi01.jpg,12.9,36016200.00,37653300.00,Milwaukee Bucks
+13,Thanasis Antetokounmpo,29,https://www.basketball-reference.com/req/202106291/images/players/antetth01.jpg,0.9,36000000.00,38482759.00,Milwaukee Bucks
+14,Carmelo Anthony,37,https://www.basketball-reference.com/req/202106291/images/players/anthoca01.jpg,3.6,35500000.00,37948276.00,Los Angeles Lakers
+15,Cole Anthony,21,https://www.basketball-reference.com/req/202106291/images/players/anthoco01.jpg,1.6,35361360.00,37980720.00,Orlando Magic
+16,OG Anunoby,24,https://www.basketball-reference.com/req/202106291/images/players/anunoog01.jpg,3.7,35344828.00,38172414.00,Toronto Raptors
+17,Ryan Arcidiacono,27,https://www.basketball-reference.com/req/202106291/images/players/arcidry01.jpg,0.1,34916200.00,36503300.00,New York Knicks
+18,Trevor Ariza,36,https://www.basketball-reference.com/req/202106291/images/players/arizatr01.jpg,0.2,34502130.00,37262300.00,Los Angeles Lakers
+19,D.J. Augustin,34,https://www.basketball-reference.com/req/202106291/images/players/augusdj01.jpg,0.8,31650600.00,33833400.00,TOT
+20,Deni Avdija,21,https://www.basketball-reference.com/req/202106291/images/players/avdijde01.jpg,2.4,31610000.00,33790000.00,Washington Wizards
+21,Joel Ayayi,21,https://www.basketball-reference.com/req/202106291/images/players/ayayijo01.jpg,0,31610000.00,33790000.00,Washington Wizards
+22,Deandre Ayton,23,https://www.basketball-reference.com/req/202106291/images/players/aytonde01.jpg,7.3,31590000.00,33930000.00,Phoenix Suns
+23,Udoka Azubuike,22,https://www.basketball-reference.com/req/202106291/images/players/azubuud01.jpg,0.6,31590000.00,33930000.00,Utah Jazz
+24,Marvin Bagley III,22,https://www.basketball-reference.com/req/202106291/images/players/baglema01.jpg,2,31579390.00,33616770.00,TOT
+25,LaMelo Ball,20,https://www.basketball-reference.com/req/202106291/images/players/ballla01.jpg,5.8,31579390.00,33616770.00,Charlotte Hornets
+26,Lonzo Ball,24,https://www.basketball-reference.com/req/202106291/images/players/balllo01.jpg,2.2,31320000.00,33640000.00,Chicago Bulls
+27,Mo Bamba,23,https://www.basketball-reference.com/req/202106291/images/players/bambamo01.jpg,4.5,31300000.00,28900000.00,Orlando Magic
+28,Desmond Bane,23,https://www.basketball-reference.com/req/202106291/images/players/banede01.jpg,7.2,30864198.00,33333333.00,Memphis Grizzlies
+29,Dalano Banton,22,https://www.basketball-reference.com/req/202106291/images/players/bantoda01.jpg,0.4,30800000.00,28400000.00,Toronto Raptors
+30,Cat Barber,27,https://www.basketball-reference.com/req/202106291/images/players/barbeca01.jpg,-0.1,30510423.00,32478837.00,Atlanta Hawks
+31,Harrison Barnes,29,https://www.basketball-reference.com/req/202106291/images/players/barneha02.jpg,6,30133333.00,32393333.00,Sacramento Kings
+32,Scottie Barnes,20,https://www.basketball-reference.com/req/202106291/images/players/barnesc01.jpg,6.6,30013500.00,31377750.00,Toronto Raptors
+33,RJ Barrett,21,https://www.basketball-reference.com/req/202106291/images/players/barrerj01.jpg,2.3,29900000.00,30100000.00,New York Knicks
+34,Will Barton,31,https://www.basketball-reference.com/req/202106291/images/players/bartowi01.jpg,3.2,32405817.00,,Denver Nuggets
+35,Paris Bass,26,https://www.basketball-reference.com/req/202106291/images/players/basspa01.jpg,0,29467800.00,31650600.00,Phoenix Suns
+36,Charles Bassey,21,https://www.basketball-reference.com/req/202106291/images/players/bassech01.jpg,0.8,28103550.00,30351834.00,Philadelphia 76ers
+37,Keita Bates-Diop,26,https://www.basketball-reference.com/req/202106291/images/players/bateske01.jpg,1.6,28103550.00,30351834.00,San Antonio Spurs
+38,Nicolas Batum,33,https://www.basketball-reference.com/req/202106291/images/players/batumni01.jpg,3.7,28103550.00,30351834.00,Los Angeles Clippers
+39,Kent Bazemore,32,https://www.basketball-reference.com/req/202106291/images/players/bazemke01.jpg,0.1,28103550.00,30351834.00,Los Angeles Lakers
+40,Darius Bazley,21,https://www.basketball-reference.com/req/202106291/images/players/bazleda01.jpg,1.8,27000000.00,26500000.00,Oklahoma City Thunder
+41,Bradley Beal,28,https://www.basketball-reference.com/req/202106291/images/players/bealbr01.jpg,1.4,26984128.00,28333334.00,Washington Wizards
+42,Malik Beasley,25,https://www.basketball-reference.com/req/202106291/images/players/beaslma01.jpg,2.9,34967442.00,36596549.00,Minnesota Timberwolves
+43,Jordan Bell,27,https://www.basketball-reference.com/req/202106291/images/players/belljo01.jpg,0,26000000.00,27300000.00,Chicago Bulls
+44,DeAndre' Bembry,27,https://www.basketball-reference.com/req/202106291/images/players/bembrde01.jpg,2.2,24830357.00,26669643.00,TOT
+45,Dāvis Bertāns,29,https://www.basketball-reference.com/req/202106291/images/players/bertada01.jpg,0.9,24026712.00,25806469.00,TOT
+46,Patrick Beverley,33,https://www.basketball-reference.com/req/202106291/images/players/beverpa01.jpg,4.1,24000000.00,22000000.00,Minnesota Timberwolves
+47,Saddiq Bey,22,https://www.basketball-reference.com/req/202106291/images/players/beysa01.jpg,4,23000000.00,23500000.00,Detroit Pistons
+48,Khem Birch,29,https://www.basketball-reference.com/req/202106291/images/players/birchkh01.jpg,2.6,22477273.00,20522727.00,Toronto Raptors
+49,Goga Bitadze,22,https://www.basketball-reference.com/req/202106291/images/players/bitadgo01.jpg,1.9,21700000.00,22600000.00,Indiana Pacers
+50,Bismack Biyombo,29,https://www.basketball-reference.com/req/202106291/images/players/biyombi01.jpg,1.8,21306816.00,19602273.00,Phoenix Suns
+51,Nemanja Bjelica,33,https://www.basketball-reference.com/req/202106291/images/players/bjeline01.jpg,3,21000000.00,22680000.00,Golden State Warriors
+52,Eric Bledsoe,32,https://www.basketball-reference.com/req/202106291/images/players/bledser01.jpg,1.3,20482143.00,,Los Angeles Clippers
+53,Keljin Blevins,26,https://www.basketball-reference.com/req/202106291/images/players/blevike01.jpg,-0.5,20475000.00,21450000.00,Portland Trail Blazers
+54,Bogdan Bogdanović,29,https://www.basketball-reference.com/req/202106291/images/players/bogdabo01.jpg,3.7,20284091.00,18352273.00,Atlanta Hawks
+55,Bojan Bogdanović,32,https://www.basketball-reference.com/req/202106291/images/players/bogdabo02.jpg,5.2,20000000.00,20000000.00,Utah Jazz
+56,Bol Bol,22,https://www.basketball-reference.com/req/202106291/images/players/bolbo01.jpg,0.1,20000000.00,20952381.00,Denver Nuggets
+57,Leandro Bolmaro,21,https://www.basketball-reference.com/req/202106291/images/players/bolmale01.jpg,0,19800000.00,23760000.00,Minnesota Timberwolves
+58,Isaac Bonga,22,https://www.basketball-reference.com/req/202106291/images/players/bongais01.jpg,0.1,19675926.00,21250000.00,Toronto Raptors
+59,Devin Booker,25,https://www.basketball-reference.com/req/202106291/images/players/bookede01.jpg,7.6,19500000.00,,Phoenix Suns
+60,Brandon Boston Jr.,20,https://www.basketball-reference.com/req/202106291/images/players/bostobr01.jpg,0.4,20168742.00,,Los Angeles Clippers
+61,Chris Boucher,29,https://www.basketball-reference.com/req/202106291/images/players/bouchch01.jpg,6,18700000.00,19550000.00,Toronto Raptors
+62,James Bouknight,21,https://www.basketball-reference.com/req/202106291/images/players/bouknja01.jpg,0,18604651.00,19534884.00,Charlotte Hornets
+63,Avery Bradley,31,https://www.basketball-reference.com/req/202106291/images/players/bradlav01.jpg,1.2,18562500.00,19937500.00,Los Angeles Lakers
+64,Tony Bradley,24,https://www.basketball-reference.com/req/202106291/images/players/bradlto01.jpg,1.3,18218818.00,19568360.00,Chicago Bulls
+65,Ignas Brazdeikis,23,https://www.basketball-reference.com/req/202106291/images/players/brazdig01.jpg,0.5,18139535.00,19046512.00,Orlando Magic
+66,Mikal Bridges,25,https://www.basketball-reference.com/req/202106291/images/players/bridgmi01.jpg,8.9,18125000.00,19375000.00,Phoenix Suns
+67,Miles Bridges,23,https://www.basketball-reference.com/req/202106291/images/players/bridgmi02.jpg,7.2,18000000.00,18000000.00,Charlotte Hornets
+68,Oshae Brissett,23,https://www.basketball-reference.com/req/202106291/images/players/brissos01.jpg,2.2,18000000.00,18000000.00,Indiana Pacers
+69,Malcolm Brogdon,29,https://www.basketball-reference.com/req/202106291/images/players/brogdma01.jpg,2.7,17905263.00,21486316.00,Indiana Pacers
+70,Armoni Brooks,23,https://www.basketball-reference.com/req/202106291/images/players/brookar01.jpg,0.2,17809524.00,,TOT
+71,Dillon Brooks,26,https://www.basketball-reference.com/req/202106291/images/players/brookdi01.jpg,1.6,17500000.00,18796296.00,Memphis Grizzlies
+72,Bruce Brown,25,https://www.basketball-reference.com/req/202106291/images/players/brownbr01.jpg,4.8,17400000.00,17400000.00,Brooklyn Nets
+73,Charlie Brown Jr.,24,https://www.basketball-reference.com/req/202106291/images/players/brownch02.jpg,0,17357143.00,18642857.00,TOT
+74,Chaundee Brown Jr.,23,https://www.basketball-reference.com/req/202106291/images/players/brownch05.jpg,0,17142857.00,18000000.00,TOT
+75,Greg Brown III,20,https://www.basketball-reference.com/req/202106291/images/players/browngr01.jpg,0.4,17103448.00,18206897.00,Portland Trail Blazers
+76,Jaylen Brown,25,https://www.basketball-reference.com/req/202106291/images/players/brownja02.jpg,5.8,17073171.00,17926829.00,Boston Celtics
+77,Moses Brown,22,https://www.basketball-reference.com/req/202106291/images/players/brownmo01.jpg,1.2,16500000.00,16500000.00,TOT
+78,Sterling Brown,26,https://www.basketball-reference.com/req/202106291/images/players/brownst02.jpg,0.8,16409091.00,19690909.00,Dallas Mavericks
+79,Troy Brown Jr.,22,https://www.basketball-reference.com/req/202106291/images/players/browntr01.jpg,1.4,16071429.00,17357143.00,Chicago Bulls
+80,Jalen Brunson,25,https://www.basketball-reference.com/req/202106291/images/players/brunsja01.jpg,7.5,16000000.00,16000000.00,Dallas Mavericks
+81,Thomas Bryant,24,https://www.basketball-reference.com/req/202106291/images/players/bryanth01.jpg,1.1,16000000.00,17280000.00,Washington Wizards
+82,Shaq Buchanan,25,https://www.basketball-reference.com/req/202106291/images/players/buchash01.jpg,0,15690909.00,16475454.00,Memphis Grizzlies
+83,Reggie Bullock,30,https://www.basketball-reference.com/req/202106291/images/players/bullore01.jpg,3.2,15627907.00,16372093.00,Dallas Mavericks
+84,Trey Burke,29,https://www.basketball-reference.com/req/202106291/images/players/burketr01.jpg,0,15560000.00,16902000.00,Dallas Mavericks
+85,Alec Burks,30,https://www.basketball-reference.com/req/202106291/images/players/burksal01.jpg,6.1,15517242.00,16758621.00,New York Knicks
+86,Jared Butler,21,https://www.basketball-reference.com/req/202106291/images/players/butleja02.jpg,0.4,15428571.00,16571429.00,Utah Jazz
+87,Jimmy Butler,32,https://www.basketball-reference.com/req/202106291/images/players/butleji01.jpg,9.2,15384615.00,16615385.00,Miami Heat
+88,Devontae Cacok,25,https://www.basketball-reference.com/req/202106291/images/players/cacokde01.jpg,0.5,15178571.00,16392857.00,San Antonio Spurs
+89,Kentavious Caldwell-Pope,28,https://www.basketball-reference.com/req/202106291/images/players/caldwke01.jpg,2.8,15057692.00,,Washington Wizards
+90,Facundo Campazzo,30,https://www.basketball-reference.com/req/202106291/images/players/campafa01.jpg,2,14391964.00,15458035.00,Denver Nuggets
+91,Vlatko Čančar,24,https://www.basketball-reference.com/req/202106291/images/players/cancavl01.jpg,0.4,14339285.00,16607142.00,Denver Nuggets
+92,Devin Cannady,25,https://www.basketball-reference.com/req/202106291/images/players/cannade01.jpg,0.1,14320988.00,13000000.00,Orlando Magic
+93,Clint Capela,27,https://www.basketball-reference.com/req/202106291/images/players/capelca01.jpg,8.3,14190000.00,,Atlanta Hawks
+94,Vernon Carey Jr.,20,https://www.basketball-reference.com/req/202106291/images/players/careyve01.jpg,0.1,14000000.00,14700000.00,TOT
+95,Jevon Carter,26,https://www.basketball-reference.com/req/202106291/images/players/carteje01.jpg,1.2,14000000.00,,TOT
+96,Wendell Carter Jr.,22,https://www.basketball-reference.com/req/202106291/images/players/cartewe01.jpg,5,13750000.00,13750000.00,Orlando Magic
+97,Alex Caruso,27,https://www.basketball-reference.com/req/202106291/images/players/carusal01.jpg,2,13666667.00,14317459.00,Chicago Bulls
+98,Willie Cauley-Stein,28,https://www.basketball-reference.com/req/202106291/images/players/caulewi01.jpg,0.2,13445120.00,14520730.00,TOT
+99,Ahmad Caver,25,https://www.basketball-reference.com/req/202106291/images/players/caverah01.jpg,0,13302325.00,13906976.00,Indiana Pacers
+100,Justin Champagnie,20,https://www.basketball-reference.com/req/202106291/images/players/champju01.jpg,0.8,13038862.00,14004703.00,Toronto Raptors
+101,Zylan Cheatham,26,https://www.basketball-reference.com/req/202106291/images/players/cheatzy01.jpg,-0.1,13000000.00,13000000.00,Utah Jazz
+102,Chris Chiozza,26,https://www.basketball-reference.com/req/202106291/images/players/chiozch01.jpg,0,12975471.00,,Golden State Warriors
+103,Marquese Chriss,24,https://www.basketball-reference.com/req/202106291/images/players/chrisma01.jpg,0.8,12727273.00,13745455.00,Dallas Mavericks
+104,Josh Christopher,20,https://www.basketball-reference.com/req/202106291/images/players/chrisjo01.jpg,0.3,12690000.00,,Houston Rockets
+105,Gary Clark,27,https://www.basketball-reference.com/req/202106291/images/players/clarkga01.jpg,0.7,12632950.00,,New Orleans Pelicans
+106,Brandon Clarke,25,https://www.basketball-reference.com/req/202106291/images/players/clarkbr01.jpg,6.3,12500000.00,11500000.00,Memphis Grizzlies
+107,Jordan Clarkson,29,https://www.basketball-reference.com/req/202106291/images/players/clarkjo01.jpg,3.5,12420000.00,13340000.00,Utah Jazz
+108,Nic Claxton,22,https://www.basketball-reference.com/req/202106291/images/players/claxtni01.jpg,3.5,12200000.00,11400000.00,Brooklyn Nets
+109,Amir Coffey,24,https://www.basketball-reference.com/req/202106291/images/players/coffeam01.jpg,3.8,12195122.00,12804878.00,Los Angeles Clippers
+110,John Collins,24,https://www.basketball-reference.com/req/202106291/images/players/collijo01.jpg,5.1,12000000.00,12600000.00,Atlanta Hawks
+111,Zach Collins,24,https://www.basketball-reference.com/req/202106291/images/players/colliza01.jpg,1.2,12000000.00,12960000.00,San Antonio Spurs
+112,Darren Collison,34,https://www.basketball-reference.com/req/202106291/images/players/collida01.jpg,-0.1,12000000.00,,Los Angeles Lakers
+113,Mike Conley,34,https://www.basketball-reference.com/req/202106291/images/players/conlemi01.jpg,6.7,11615328.00,12196094.00,Utah Jazz
+114,Pat Connaughton,29,https://www.basketball-reference.com/req/202106291/images/players/connapa01.jpg,4.4,11312114.00,,Milwaukee Bucks
+115,Tyler Cook,24,https://www.basketball-reference.com/req/202106291/images/players/cookty01.jpg,0.5,11000000.00,11550000.00,Chicago Bulls
+116,Sharife Cooper,20,https://www.basketball-reference.com/req/202106291/images/players/coopesh01.jpg,-0.2,11000000.00,11814815.00,Atlanta Hawks
+117,Petr Cornelie,26,https://www.basketball-reference.com/req/202106291/images/players/cornepe01.jpg,0,10733400.00,13534817.00,Denver Nuggets
+118,DeMarcus Cousins,31,https://www.basketball-reference.com/req/202106291/images/players/couside01.jpg,1.6,10690909.00,9672727.00,TOT
+119,Robert Covington,31,https://www.basketball-reference.com/req/202106291/images/players/covinro01.jpg,3.2,10500000.00,,TOT
+120,Torrey Craig,31,https://www.basketball-reference.com/req/202106291/images/players/craigto01.jpg,2.3,10384500.00,11215260.00,TOT
+121,Jae Crowder,31,https://www.basketball-reference.com/req/202106291/images/players/crowdja01.jpg,4.3,10384500.00,11215260.00,Phoenix Suns
+122,Jarrett Culver,22,https://www.basketball-reference.com/req/202106291/images/players/culveja01.jpg,0.1,10245480.00,10733400.00,Memphis Grizzlies
+123,Jarron Cumberland,24,https://www.basketball-reference.com/req/202106291/images/players/cumbeja01.jpg,0,10174391.00,35700000.00,Portland Trail Blazers
+124,Cade Cunningham,20,https://www.basketball-reference.com/req/202106291/images/players/cunnica01.jpg,-0.5,10050120.00,10552800.00,Detroit Pistons
+125,Seth Curry,31,https://www.basketball-reference.com/req/202106291/images/players/curryse01.jpg,4.2,10468119.00,,TOT
+126,Stephen Curry,33,https://www.basketball-reference.com/req/202106291/images/players/curryst01.jpg,8,10000000.00,10000000.00,Golden State Warriors
+127,Anthony Davis,28,https://www.basketball-reference.com/req/202106291/images/players/davisan02.jpg,4.5,9937150.00,,Los Angeles Lakers
+128,Ed Davis,32,https://www.basketball-reference.com/req/202106291/images/players/davised01.jpg,0.5,9742000.00,,Cleveland Cavaliers
+129,Terence Davis,24,https://www.basketball-reference.com/req/202106291/images/players/daviste02.jpg,0.5,9720900.00,10183800.00,Sacramento Kings
+130,Gabriel Deck,26,https://www.basketball-reference.com/req/202106291/images/players/deckga01.jpg,0.1,9720900.00,10183800.00,Oklahoma City Thunder
+131,Dewayne Dedmon,32,https://www.basketball-reference.com/req/202106291/images/players/dedmode01.jpg,3.5,10720900.00,,Miami Heat
+132,Sam Dekker,27,https://www.basketball-reference.com/req/202106291/images/players/dekkesa01.jpg,0,9720900.00,,Toronto Raptors
+133,Javin DeLaurier,23,https://www.basketball-reference.com/req/202106291/images/players/delauja01.jpg,0,9720900.00,,Milwaukee Bucks
+134,DeMar DeRozan,32,https://www.basketball-reference.com/req/202106291/images/players/derozde01.jpg,8.8,9603360.00,12119440.00,Chicago Bulls
+135,Mamadi Diakite,25,https://www.basketball-reference.com/req/202106291/images/players/diakima01.jpg,0.3,9536000.00,10012800.00,Oklahoma City Thunder
+136,Cheick Diallo,25,https://www.basketball-reference.com/req/202106291/images/players/diallch01.jpg,0.1,9536000.00,10012800.00,Detroit Pistons
+137,Hamidou Diallo,23,https://www.basketball-reference.com/req/202106291/images/players/diallha01.jpg,2.1,9500000.00,10260000.00,Detroit Pistons
+138,Gorgui Dieng,32,https://www.basketball-reference.com/req/202106291/images/players/dienggo01.jpg,1.2,9180560.00,23437500.00,Atlanta Hawks
+139,Spencer Dinwiddie,28,https://www.basketball-reference.com/req/202106291/images/players/dinwisp01.jpg,4.1,9166800.00,9603360.00,TOT
+140,Donte DiVincenzo,25,https://www.basketball-reference.com/req/202106291/images/players/divindo01.jpg,0.7,12213507.00,12372008.00,TOT
+141,Luka Dončić,22,https://www.basketball-reference.com/req/202106291/images/players/doncilu01.jpg,7.6,9000000.00,9666667.00,Dallas Mavericks
+142,Luguentz Dort,22,https://www.basketball-reference.com/req/202106291/images/players/dortlu01.jpg,1.4,8992200.00,9441720.00,Oklahoma City Thunder
+143,Ayo Dosunmu,22,https://www.basketball-reference.com/req/202106291/images/players/dosunay01.jpg,3,8800000.00,9240000.00,Chicago Bulls
+144,Damyean Dotson,27,https://www.basketball-reference.com/req/202106291/images/players/dotsoda01.jpg,0,8750000.00,9398148.00,New York Knicks
+145,Devon Dotson,22,https://www.basketball-reference.com/req/202106291/images/players/dotsode01.jpg,0.1,8750000.00,9000000.00,Chicago Bulls
+146,Sekou Doumbouya,21,https://www.basketball-reference.com/req/202106291/images/players/doumbse01.jpg,0.1,8730159.00,,Los Angeles Lakers
+147,Jeff Dowtin,24,https://www.basketball-reference.com/req/202106291/images/players/dowtije01.jpg,0,34967442.00,36596549.00,TOT
+148,PJ Dozier,25,https://www.basketball-reference.com/req/202106291/images/players/doziepj01.jpg,0.3,8678571.00,9321429.00,Denver Nuggets
+149,Goran Dragić,35,https://www.basketball-reference.com/req/202106291/images/players/dragigo01.jpg,0.4,8623920.00,10900635.00,TOT
+150,Andre Drummond,28,https://www.basketball-reference.com/req/202106291/images/players/drumman01.jpg,5.1,8604651.00,9034884.00,TOT
+151,Chris Duarte,24,https://www.basketball-reference.com/req/202106291/images/players/duartch01.jpg,0.9,8526316.00,,Indiana Pacers
+152,David Duke Jr.,22,https://www.basketball-reference.com/req/202106291/images/players/dukeda01.jpg,0.3,8437500.00,9062500.00,Brooklyn Nets
+153,Kris Dunn,27,https://www.basketball-reference.com/req/202106291/images/players/dunnkr01.jpg,0.2,8372093.00,8790698.00,Portland Trail Blazers
+154,Kevin Durant,33,https://www.basketball-reference.com/req/202106291/images/players/duranke01.jpg,8.4,8333333.00,9000000.00,Brooklyn Nets
+155,Jaime Echenique,24,https://www.basketball-reference.com/req/202106291/images/players/echenja01.jpg,0,8326471.00,29750000.00,Washington Wizards
+156,Anthony Edwards,20,https://www.basketball-reference.com/req/202106291/images/players/edwaran01.jpg,4.3,8292683.00,8707317.00,Minnesota Timberwolves
+157,Carsen Edwards,23,https://www.basketball-reference.com/req/202106291/images/players/edwarca01.jpg,-0.1,8231760.00,8623920.00,Detroit Pistons
+158,Kessler Edwards,21,https://www.basketball-reference.com/req/202106291/images/players/edwarke02.jpg,0.6,8186047.00,8558140.00,Brooklyn Nets
+159,Rob Edwards,25,https://www.basketball-reference.com/req/202106291/images/players/edwarro01.jpg,0,8137500.00,8525000.00,Oklahoma City Thunder
+160,CJ Elleby,21,https://www.basketball-reference.com/req/202106291/images/players/ellebcj01.jpg,0.4,8075160.00,8478720.00,Portland Trail Blazers
+161,Wayne Ellington,34,https://www.basketball-reference.com/req/202106291/images/players/ellinwa01.jpg,1,8050000.00,7350000.00,Los Angeles Lakers
+162,Joel Embiid,27,https://www.basketball-reference.com/req/202106291/images/players/embiijo01.jpg,12,11109327.00,7827907.00,Philadelphia 76ers
+163,James Ennis III,31,https://www.basketball-reference.com/req/202106291/images/players/ennisja01.jpg,0.1,7775400.00,9835881.00,TOT
+164,Drew Eubanks,24,https://www.basketball-reference.com/req/202106291/images/players/eubandr01.jpg,3.4,7568742.00,,TOT
+165,Tacko Fall,26,https://www.basketball-reference.com/req/202106291/images/players/fallta01.jpg,0.1,7522200.00,,Cleveland Cavaliers
+166,Derrick Favors,30,https://www.basketball-reference.com/req/202106291/images/players/favorde01.jpg,1.4,7518518.00,7518518.00,Oklahoma City Thunder
+167,Bruno Fernando,23,https://www.basketball-reference.com/req/202106291/images/players/fernabr01.jpg,0.4,7500000.00,8100000.00,TOT
+168,Dorian Finney-Smith,28,https://www.basketball-reference.com/req/202106291/images/players/finnedo01.jpg,6.6,7422000.00,7775400.00,Dallas Mavericks
+169,Malik Fitts,24,https://www.basketball-reference.com/req/202106291/images/players/fittsma01.jpg,0.1,7280520.00,7644720.00,TOT
+170,Malachi Flynn,23,https://www.basketball-reference.com/req/202106291/images/players/flynnma01.jpg,1,7040880.00,8920795.00,Toronto Raptors
+171,Bryn Forbes,28,https://www.basketball-reference.com/req/202106291/images/players/forbebr01.jpg,1.4,7009615.00,,TOT
+172,Aleem Ford,24,https://www.basketball-reference.com/req/202106291/images/players/fordal03.jpg,-0.2,7622467.00,333333.00,Orlando Magic
+173,Trent Forrest,23,https://www.basketball-reference.com/req/202106291/images/players/forretr01.jpg,1.3,7000000.00,7350000.00,Utah Jazz
+174,Evan Fournier,29,https://www.basketball-reference.com/req/202106291/images/players/fournev01.jpg,3.7,6984127.00,7333333.00,New York Knicks
+175,De'Aaron Fox,24,https://www.basketball-reference.com/req/202106291/images/players/foxde01.jpg,2.5,6920027.00,14150000.00,Sacramento Kings
+176,Melvin Frazier,25,https://www.basketball-reference.com/req/202106291/images/players/frazime01.jpg,-0.4,6720720.00,7040880.00,Oklahoma City Thunder
+177,Tim Frazier,31,https://www.basketball-reference.com/req/202106291/images/players/fraziti01.jpg,-0.2,6593040.00,6922440.00,TOT
+178,Enes Freedom,29,https://www.basketball-reference.com/req/202106291/images/players/kanteen01.jpg,1.4,6500000.00,6000000.00,Boston Celtics
+179,Markelle Fultz,23,https://www.basketball-reference.com/req/202106291/images/players/fultzma01.jpg,0.4,6431666.00,,Orlando Magic
+180,Wenyen Gabriel,24,https://www.basketball-reference.com/req/202106291/images/players/gabriwe01.jpg,0.7,6395160.00,8109063.00,TOT
+181,Daniel Gafford,23,https://www.basketball-reference.com/req/202106291/images/players/gaffoda01.jpg,6,6350000.00,6667750.00,Washington Wizards
+182,Danilo Gallinari,33,https://www.basketball-reference.com/req/202106291/images/players/gallida01.jpg,3.6,6349671.00,,Atlanta Hawks
+183,Langston Galloway,30,https://www.basketball-reference.com/req/202106291/images/players/gallola01.jpg,-0.2,6175440.00,6632880.00,TOT
+184,Darius Garland,22,https://www.basketball-reference.com/req/202106291/images/players/garlada01.jpg,6.3,6104280.00,6395160.00,Cleveland Cavaliers
+185,Marcus Garrett,23,https://www.basketball-reference.com/req/202106291/images/players/garrema01.jpg,0.1,6006420.00,6292440.00,Miami Heat
+186,Usman Garuba,19,https://www.basketball-reference.com/req/202106291/images/players/garubus01.jpg,0.5,5988000.00,6287400.00,Houston Rockets
+187,Luka Garza,23,https://www.basketball-reference.com/req/202106291/images/players/garzalu01.jpg,0.8,5890000.00,6184500.00,Detroit Pistons
+188,Rudy Gay,35,https://www.basketball-reference.com/req/202106291/images/players/gayru01.jpg,2.1,5890000.00,,Utah Jazz
+189,Paul George,31,https://www.basketball-reference.com/req/202106291/images/players/georgpa01.jpg,1.3,5890000.00,6184500.00,Los Angeles Clippers
+190,Taj Gibson,36,https://www.basketball-reference.com/req/202106291/images/players/gibsota01.jpg,2.7,5845978.00,,New York Knicks
+191,Josh Giddey,19,https://www.basketball-reference.com/req/202106291/images/players/giddejo01.jpg,0.4,5837760.00,7413955.00,Oklahoma City Thunder
+192,Shai Gilgeous-Alexander,23,https://www.basketball-reference.com/req/202106291/images/players/gilgesh01.jpg,4.6,5573334.00,,Oklahoma City Thunder
+193,Anthony Gill,29,https://www.basketball-reference.com/req/202106291/images/players/gillan01.jpg,1.4,5572680.00,5837760.00,Washington Wizards
+194,Freddie Gillespie,24,https://www.basketball-reference.com/req/202106291/images/players/gillefr01.jpg,0.1,5557725.00,20089286.00,Orlando Magic
+195,Rudy Gobert,29,https://www.basketball-reference.com/req/202106291/images/players/goberru01.jpg,11.7,5495532.00,29750000.00,Utah Jazz
+196,Brandon Goodwin,26,https://www.basketball-reference.com/req/202106291/images/players/goodwbr01.jpg,0.7,5466360.00,5739960.00,Cleveland Cavaliers
+197,Jordan Goodwin,23,https://www.basketball-reference.com/req/202106291/images/players/goodwjo01.jpg,-0.1,5421493.00,,Washington Wizards
+198,Aaron Gordon,26,https://www.basketball-reference.com/req/202106291/images/players/gordoaa01.jpg,5.2,5348280.00,6803012.00,Denver Nuggets
+199,Eric Gordon,33,https://www.basketball-reference.com/req/202106291/images/players/gordoer01.jpg,1.4,5333333.00,5728395.00,Houston Rockets
+200,Devonte' Graham,26,https://www.basketball-reference.com/req/202106291/images/players/grahade01.jpg,2.8,5258735.00,29750000.00,New Orleans Pelicans
+201,Jerami Grant,27,https://www.basketball-reference.com/req/202106291/images/players/grantje01.jpg,2.3,5214584.00,,Detroit Pistons
+202,Hassani Gravett,25,https://www.basketball-reference.com/req/202106291/images/players/graveha01.jpg,0.3,5200000.00,5200000.00,Orlando Magic
+203,Danny Green,34,https://www.basketball-reference.com/req/202106291/images/players/greenda02.jpg,1.9,5178572.00,,Philadelphia 76ers
+204,Draymond Green,31,https://www.basketball-reference.com/req/202106291/images/players/greendr01.jpg,3.6,5170564.00,,Golden State Warriors
+205,Jalen Green,19,https://www.basketball-reference.com/req/202106291/images/players/greenja05.jpg,0.7,5105160.00,5348280.00,Houston Rockets
+206,JaMychal Green,31,https://www.basketball-reference.com/req/202106291/images/players/greenja01.jpg,2.7,5007840.00,5258280.00,Denver Nuggets
+207,Javonte Green,28,https://www.basketball-reference.com/req/202106291/images/players/greenja02.jpg,4.4,5005350.00,,Chicago Bulls
+208,Jeff Green,35,https://www.basketball-reference.com/req/202106291/images/players/greenje02.jpg,3.9,5000000.00,,Denver Nuggets
+209,Josh Green,21,https://www.basketball-reference.com/req/202106291/images/players/greenjo02.jpg,2.4,5000000.00,,Dallas Mavericks
+210,Blake Griffin,32,https://www.basketball-reference.com/req/202106291/images/players/griffbl01.jpg,2.1,5000000.00,5250000.00,Brooklyn Nets
+211,Quentin Grimes,21,https://www.basketball-reference.com/req/202106291/images/players/grimequ01.jpg,1.4,5000000.00,,New York Knicks
+212,Kyle Guy,24,https://www.basketball-reference.com/req/202106291/images/players/guyky01.jpg,0.1,4990000.00,,Miami Heat
+213,Rui Hachimura,23,https://www.basketball-reference.com/req/202106291/images/players/hachiru01.jpg,1.4,4916160.00,6263188.00,Washington Wizards
+214,Tyrese Haliburton,21,https://www.basketball-reference.com/req/202106291/images/players/halibty01.jpg,7,4910000.00,5155500.00,TOT
+215,Tyler Hall,24,https://www.basketball-reference.com/req/202106291/images/players/hallty01.jpg,0,7310000.00,5155000.00,New York Knicks
+216,R.J. Hampton,20,https://www.basketball-reference.com/req/202106291/images/players/hamptrj01.jpg,-0.2,4910000.00,5155500.00,Orlando Magic
+217,Tim Hardaway Jr.,29,https://www.basketball-reference.com/req/202106291/images/players/hardati02.jpg,2,4878049.00,5121951.00,Dallas Mavericks
+218,James Harden,32,https://www.basketball-reference.com/req/202106291/images/players/hardeja01.jpg,7.6,2641691.00,,TOT
+219,Maurice Harkless,28,https://www.basketball-reference.com/req/202106291/images/players/harklma01.jpg,0.5,4736102.00,,Sacramento Kings
+220,Jared Harper,24,https://www.basketball-reference.com/req/202106291/images/players/harpeja01.jpg,0.4,4692840.00,4916160.00,New Orleans Pelicans
+221,Montrezl Harrell,28,https://www.basketball-reference.com/req/202106291/images/players/harremo01.jpg,7.3,4675830.00,,TOT
+222,Gary Harris,27,https://www.basketball-reference.com/req/202106291/images/players/harriga01.jpg,2.2,4670160.00,5954454.00,Orlando Magic
+223,Joe Harris,30,https://www.basketball-reference.com/req/202106291/images/players/harrijo01.jpg,0.5,4650000.00,5022000.00,Brooklyn Nets
+224,Tobias Harris,29,https://www.basketball-reference.com/req/202106291/images/players/harrito02.jpg,5.6,4629630.00,5000000.00,Philadelphia 76ers
+225,Shaquille Harrison,28,https://www.basketball-reference.com/req/202106291/images/players/harrish01.jpg,0,4603320.00,4833600.00,Brooklyn Nets
+226,Josh Hart,26,https://www.basketball-reference.com/req/202106291/images/players/hartjo01.jpg,4.4,4500000.00,4725000.00,TOT
+227,Isaiah Hartenstein,23,https://www.basketball-reference.com/req/202106291/images/players/harteis01.jpg,5.5,4500000.00,4500000.00,Los Angeles Clippers
+228,Udonis Haslem,41,https://www.basketball-reference.com/req/202106291/images/players/hasleud01.jpg,0.1,4458000.00,4670160.00,Miami Heat
+229,Sam Hauser,24,https://www.basketball-reference.com/req/202106291/images/players/hausesa01.jpg,0.6,4447896.00,,Boston Celtics
+230,Jaxson Hayes,21,https://www.basketball-reference.com/req/202106291/images/players/hayesja02.jpg,5.1,4437000.00,5887899.00,New Orleans Pelicans
+231,Killian Hayes,20,https://www.basketball-reference.com/req/202106291/images/players/hayeski01.jpg,0.5,4373160.00,4591920.00,Detroit Pistons
+232,Gordon Hayward,31,https://www.basketball-reference.com/req/202106291/images/players/haywago01.jpg,2.8,4347600.00,4564980.00,Charlotte Hornets
+233,Aaron Henry,22,https://www.basketball-reference.com/req/202106291/images/players/henryaa01.jpg,-0.1,4347600.00,4564980.00,Philadelphia 76ers
+234,Juancho Hernangómez,26,https://www.basketball-reference.com/req/202106291/images/players/hernaju01.jpg,0.9,4259259.00,4600000.00,TOT
+235,Willy Hernangómez,27,https://www.basketball-reference.com/req/202106291/images/players/hernawi01.jpg,3.2,4253357.00,14508929.00,New Orleans Pelicans
+236,Tyler Herro,22,https://www.basketball-reference.com/req/202106291/images/players/herroty01.jpg,3.8,4235160.00,4437000.00,Miami Heat
+237,Buddy Hield,29,https://www.basketball-reference.com/req/202106291/images/players/hieldbu01.jpg,1.9,4215120.00,5808435.00,TOT
+238,Haywood Highsmith,25,https://www.basketball-reference.com/req/202106291/images/players/highsha01.jpg,0.1,4154400.00,4362240.00,Miami Heat
+239,George Hill,35,https://www.basketball-reference.com/req/202106291/images/players/hillge01.jpg,2.3,4087904.00,,Milwaukee Bucks
+240,Malcolm Hill,26,https://www.basketball-reference.com/req/202106291/images/players/hillma01.jpg,0.6,4054695.00,9615385.00,TOT
+241,Solomon Hill,30,https://www.basketball-reference.com/req/202106291/images/players/hillso01.jpg,0,4023600.00,4215120.00,Atlanta Hawks
+242,Nate Hinton,22,https://www.basketball-reference.com/req/202106291/images/players/hintona01.jpg,-0.1,4004280.00,5722116.00,Indiana Pacers
+243,Jaylen Hoard,22,https://www.basketball-reference.com/req/202106291/images/players/hoardja01.jpg,0.6,4000000.00,12402000.00,Oklahoma City Thunder
+244,Aaron Holiday,25,https://www.basketball-reference.com/req/202106291/images/players/holidaa01.jpg,1.5,4000000.00,4000000.00,TOT
+245,Jrue Holiday,31,https://www.basketball-reference.com/req/202106291/images/players/holidjr01.jpg,6.9,4000000.00,4000000.00,Milwaukee Bucks
+246,Justin Holiday,32,https://www.basketball-reference.com/req/202106291/images/players/holidju01.jpg,1.4,4000000.00,,TOT
+247,Richaun Holmes,28,https://www.basketball-reference.com/req/202106291/images/players/holmeri01.jpg,3.2,3980551.00,,Sacramento Kings
+248,Rodney Hood,29,https://www.basketball-reference.com/req/202106291/images/players/hoodro01.jpg,0.7,3946800.00,4144320.00,TOT
+249,Scotty Hopson,32,https://www.basketball-reference.com/req/202106291/images/players/hopsosc01.jpg,0,3940184.00,,Oklahoma City Thunder
+250,Al Horford,35,https://www.basketball-reference.com/req/202106291/images/players/horfoal01.jpg,7.6,3938818.00,,Boston Celtics
+251,Talen Horton-Tucker,21,https://www.basketball-reference.com/req/202106291/images/players/hortota01.jpg,1.1,3902439.00,4097561.00,Los Angeles Lakers
+252,Danuel House Jr.,28,https://www.basketball-reference.com/req/202106291/images/players/houseda01.jpg,1,3822240.00,4004280.00,TOT
+253,Dwight Howard,36,https://www.basketball-reference.com/req/202106291/images/players/howardw01.jpg,3.5,3804360.00,5634257.00,Los Angeles Lakers
+254,Markus Howard,22,https://www.basketball-reference.com/req/202106291/images/players/howarma02.jpg,0.3,3804150.00,,Denver Nuggets
+255,Kevin Huerter,23,https://www.basketball-reference.com/req/202106291/images/players/huertke01.jpg,2.8,3768342.00,9598214.00,Atlanta Hawks
+256,Jay Huff,23,https://www.basketball-reference.com/req/202106291/images/players/huffja01.jpg,0,3749520.00,3936960.00,Los Angeles Lakers
+257,Elijah Hughes,23,https://www.basketball-reference.com/req/202106291/images/players/hugheel01.jpg,-0.4,3731707.00,3918293.00,TOT
+258,Feron Hunt,22,https://www.basketball-reference.com/req/202106291/images/players/huntfe01.jpg,0,3661976.00,10700000.00,New York Knicks
+259,De'Andre Hunter,24,https://www.basketball-reference.com/req/202106291/images/players/huntede01.jpg,1.1,4107149.00,3925000.00,Atlanta Hawks
+260,Chandler Hutchison,25,https://www.basketball-reference.com/req/202106291/images/players/hutchch01.jpg,0,3631200.00,3804360.00,Phoenix Suns
+261,Bones Hyland,21,https://www.basketball-reference.com/req/202106291/images/players/hylanbo01.jpg,2.4,3562080.00,3740160.00,Denver Nuggets
+262,Serge Ibaka,32,https://www.basketball-reference.com/req/202106291/images/players/ibakase01.jpg,2,3500000.00,3500000.00,TOT
+263,Andre Iguodala,38,https://www.basketball-reference.com/req/202106291/images/players/iguodan01.jpg,1.6,3500000.00,3500000.00,Golden State Warriors
+264,Joe Ingles,34,https://www.basketball-reference.com/req/202106291/images/players/inglejo01.jpg,2.2,3449400.00,3613680.00,Utah Jazz
+265,Brandon Ingram,24,https://www.basketball-reference.com/req/202106291/images/players/ingrabr01.jpg,3.9,3383640.00,3552960.00,New Orleans Pelicans
+266,Kyrie Irving,29,https://www.basketball-reference.com/req/202106291/images/players/irvinky01.jpg,3.3,3333333.00,3492063.00,Brooklyn Nets
+267,Wes Iwundu,27,https://www.basketball-reference.com/req/202106291/images/players/iwundwe01.jpg,0.1,3300000.00,3465000.00,Atlanta Hawks
+268,Frank Jackson,23,https://www.basketball-reference.com/req/202106291/images/players/jacksfr01.jpg,0.7,3277080.00,3433320.00,Detroit Pistons
+269,Isaiah Jackson,20,https://www.basketball-reference.com/req/202106291/images/players/jacksis01.jpg,1.4,3277080.00,3433320.00,Indiana Pacers
+270,Jaren Jackson Jr.,22,https://www.basketball-reference.com/req/202106291/images/players/jacksja02.jpg,5.4,3261480.00,5009633.00,Memphis Grizzlies
+271,Josh Jackson,24,https://www.basketball-reference.com/req/202106291/images/players/jacksjo02.jpg,0,3214680.00,3375480.00,TOT
+272,Justin Jackson,26,https://www.basketball-reference.com/req/202106291/images/players/jacksju01.jpg,0,12213507.00,12372008.00,TOT
+273,Reggie Jackson,31,https://www.basketball-reference.com/req/202106291/images/players/jacksre01.jpg,0.4,3169347.00,,Los Angeles Clippers
+274,LeBron James,37,https://www.basketball-reference.com/req/202106291/images/players/jamesle01.jpg,7.5,3113160.00,3261480.00,Los Angeles Lakers
+275,DeJon Jarreau,24,https://www.basketball-reference.com/req/202106291/images/players/jarrede01.jpg,0,3098400.00,4765339.00,Indiana Pacers
+276,DaQuan Jeffries,24,https://www.basketball-reference.com/req/202106291/images/players/jeffrda01.jpg,0,3053760.00,3206640.00,Memphis Grizzlies
+277,Ty Jerome,24,https://www.basketball-reference.com/req/202106291/images/players/jeromty01.jpg,0.5,3000000.00,3000000.00,Oklahoma City Thunder
+278,Isaiah Joe,22,https://www.basketball-reference.com/req/202106291/images/players/joeis01.jpg,0.4,3000000.00,,Philadelphia 76ers
+279,Alize Johnson,25,https://www.basketball-reference.com/req/202106291/images/players/johnsal02.jpg,0.1,3000000.00,3150000.00,TOT
+280,B.J. Johnson,26,https://www.basketball-reference.com/req/202106291/images/players/johnsbj01.jpg,0.1,2957520.00,3098400.00,Orlando Magic
+281,Cameron Johnson,25,https://www.basketball-reference.com/req/202106291/images/players/johnsca02.jpg,5.6,2901240.00,3046200.00,Phoenix Suns
+282,David Johnson,20,https://www.basketball-reference.com/req/202106291/images/players/johnsda08.jpg,0,5256308.00,2866667.00,Toronto Raptors
+283,Jalen Johnson,20,https://www.basketball-reference.com/req/202106291/images/players/johnsja05.jpg,0,2844429.00,2844429.00,Atlanta Hawks
+284,James Johnson,34,https://www.basketball-reference.com/req/202106291/images/players/johnsja01.jpg,1.7,2840160.00,4379527.00,Brooklyn Nets
+285,Joe Johnson,40,https://www.basketball-reference.com/req/202106291/images/players/johnsjo02.jpg,0,2824320.00,2959080.00,Boston Celtics
+286,Keldon Johnson,22,https://www.basketball-reference.com/req/202106291/images/players/johnske04.jpg,4.9,2770560.00,2909160.00,San Antonio Spurs
+287,Keon Johnson,19,https://www.basketball-reference.com/req/202106291/images/players/johnske07.jpg,-0.5,2726880.00,4343920.00,TOT
+288,Stanley Johnson,25,https://www.basketball-reference.com/req/202106291/images/players/johnsst04.jpg,1.8,2711280.00,2840160.00,Los Angeles Lakers
+289,Tyler Johnson,29,https://www.basketball-reference.com/req/202106291/images/players/johnsty01.jpg,0.1,2659560.00,2792520.00,TOT
+290,Nikola Jokić,26,https://www.basketball-reference.com/req/202106291/images/players/jokicni01.jpg,15.2,2641691.00,,Denver Nuggets
+291,Carlik Jones,24,https://www.basketball-reference.com/req/202106291/images/players/jonesca03.jpg,-0.1,2641691.00,,TOT
+292,Damian Jones,26,https://www.basketball-reference.com/req/202106291/images/players/jonesda03.jpg,3.3,2641691.00,,Sacramento Kings
+293,Derrick Jones Jr.,24,https://www.basketball-reference.com/req/202106291/images/players/jonesde02.jpg,2.2,2641691.00,,Chicago Bulls
+294,Herbert Jones,23,https://www.basketball-reference.com/req/202106291/images/players/joneshe01.jpg,4.6,2641691.00,,New Orleans Pelicans
+295,Jemerrio Jones,26,https://www.basketball-reference.com/req/202106291/images/players/jonesje01.jpg,0.1,11109327.00,7827907.00,Los Angeles Lakers
+296,Kai Jones,21,https://www.basketball-reference.com/req/202106291/images/players/joneska01.jpg,0,2641691.00,,Charlotte Hornets
+297,Mason Jones,23,https://www.basketball-reference.com/req/202106291/images/players/jonesma05.jpg,0.2,2641691.00,,Los Angeles Lakers
+298,Tre Jones,22,https://www.basketball-reference.com/req/202106291/images/players/jonestr01.jpg,2.9,2641691.00,,San Antonio Spurs
+299,Tyus Jones,25,https://www.basketball-reference.com/req/202106291/images/players/jonesty01.jpg,5.1,2641691.00,,Memphis Grizzlies
+300,DeAndre Jordan,33,https://www.basketball-reference.com/req/202106291/images/players/jordade01.jpg,1.9,2641691.00,,TOT
+301,Cory Joseph,30,https://www.basketball-reference.com/req/202106291/images/players/josepco01.jpg,2.5,2641691.00,,Detroit Pistons
+302,Georgios Kalaitzakis,23,https://www.basketball-reference.com/req/202106291/images/players/kalaige01.jpg,-0.1,2641691.00,,TOT
+303,Frank Kaminsky,28,https://www.basketball-reference.com/req/202106291/images/players/kaminfr01.jpg,0.9,32405817.00,,Phoenix Suns
+304,Luke Kennard,25,https://www.basketball-reference.com/req/202106291/images/players/kennalu01.jpg,4.5,2641691.00,,Los Angeles Clippers
+305,Braxton Key,24,https://www.basketball-reference.com/req/202106291/images/players/keybr01.jpg,0.2,2641691.00,,TOT
+306,George King,28,https://www.basketball-reference.com/req/202106291/images/players/kingge03.jpg,-0.1,2641691.00,,Dallas Mavericks
+307,Louis King,22,https://www.basketball-reference.com/req/202106291/images/players/kinglo02.jpg,0,2617800.00,4306281.00,Sacramento Kings
+308,Corey Kispert,22,https://www.basketball-reference.com/req/202106291/images/players/kispeco01.jpg,2.3,2602920.00,2726880.00,Washington Wizards
+309,Maxi Kleber,30,https://www.basketball-reference.com/req/202106291/images/players/klebima01.jpg,3,2553120.00,2681040.00,Dallas Mavericks
+310,Brandon Knight,30,https://www.basketball-reference.com/req/202106291/images/players/knighbr03.jpg,0.1,2513040.00,4264629.00,Dallas Mavericks
+311,Nathan Knight,24,https://www.basketball-reference.com/req/202106291/images/players/knighna01.jpg,1,2500000.00,2625000.00,Minnesota Timberwolves
+312,Kevin Knox,22,https://www.basketball-reference.com/req/202106291/images/players/knoxke01.jpg,0.2,2498760.00,2617800.00,TOT
+313,John Konchar,25,https://www.basketball-reference.com/req/202106291/images/players/konchjo01.jpg,4.2,2451120.00,2573760.00,Memphis Grizzlies
+314,Furkan Korkmaz,24,https://www.basketball-reference.com/req/202106291/images/players/korkmfu01.jpg,1.2,2412840.00,4220057.00,Philadelphia 76ers
+315,Luke Kornet,26,https://www.basketball-reference.com/req/202106291/images/players/kornelu01.jpg,0.4,2401537.00,,TOT
+316,Vit Krejci,21,https://www.basketball-reference.com/req/202106291/images/players/krejcvi01.jpg,0.6,2401537.00,,Oklahoma City Thunder
+317,Arnoldas Kulboka,24,https://www.basketball-reference.com/req/202106291/images/players/kulboar01.jpg,0,2401537.00,,Charlotte Hornets
+318,Jonathan Kuminga,19,https://www.basketball-reference.com/req/202106291/images/players/kuminjo01.jpg,3,2401537.00,,Golden State Warriors
+319,Kyle Kuzma,26,https://www.basketball-reference.com/req/202106291/images/players/kuzmaky01.jpg,2,7310000.00,5155000.00,Washington Wizards
+320,Anthony Lamb,24,https://www.basketball-reference.com/req/202106291/images/players/lamban01.jpg,0,2389641.00,,San Antonio Spurs
+321,Jeremy Lamb,29,https://www.basketball-reference.com/req/202106291/images/players/lambje01.jpg,1.2,2389641.00,,TOT
+322,Jock Landale,26,https://www.basketball-reference.com/req/202106291/images/players/landajo01.jpg,1.5,2389641.00,,San Antonio Spurs
+323,Romeo Langford,22,https://www.basketball-reference.com/req/202106291/images/players/langfro01.jpg,1.3,2389641.00,,TOT
+324,Zach LaVine,26,https://www.basketball-reference.com/req/202106291/images/players/lavinza01.jpg,5.8,2389641.00,,Chicago Bulls
+325,Jake Layman,27,https://www.basketball-reference.com/req/202106291/images/players/laymaja01.jpg,0.1,5256308.00,2866667.00,Minnesota Timberwolves
+326,Damion Lee,29,https://www.basketball-reference.com/req/202106291/images/players/leeda03.jpg,2.7,2389641.00,,Golden State Warriors
+327,Saben Lee,22,https://www.basketball-reference.com/req/202106291/images/players/leesa01.jpg,0.9,2353320.00,2471160.00,Detroit Pistons
+328,Alex Len,28,https://www.basketball-reference.com/req/202106291/images/players/lenal01.jpg,0.9,2353320.00,2471160.00,Sacramento Kings
+329,Caris LeVert,27,https://www.basketball-reference.com/req/202106291/images/players/leverca01.jpg,2.2,2327220.00,2443581.00,TOT
+330,Kira Lewis Jr.,20,https://www.basketball-reference.com/req/202106291/images/players/lewiski01.jpg,-0.1,2316240.00,4171548.00,New Orleans Pelicans
+331,Scottie Lewis,21,https://www.basketball-reference.com/req/202106291/images/players/lewissc01.jpg,0,2303040.00,2412840.00,Charlotte Hornets
+332,Damian Lillard,31,https://www.basketball-reference.com/req/202106291/images/players/lillada01.jpg,1.7,2259240.00,2372160.00,Portland Trail Blazers
+333,Nassir Little,21,https://www.basketball-reference.com/req/202106291/images/players/littlna01.jpg,1.7,2245400.00,,Portland Trail Blazers
+334,Isaiah Livers,23,https://www.basketball-reference.com/req/202106291/images/players/liveris01.jpg,0.7,2239544.00,,Detroit Pistons
+335,Kevon Looney,25,https://www.basketball-reference.com/req/202106291/images/players/looneke01.jpg,6.8,2239544.00,,Golden State Warriors
+336,Brook Lopez,33,https://www.basketball-reference.com/req/202106291/images/players/lopezbr01.jpg,0.7,2239200.00,4037278.00,Milwaukee Bucks
+337,Robin Lopez,33,https://www.basketball-reference.com/req/202106291/images/players/lopezro01.jpg,0.8,2210640.00,2316240.00,Orlando Magic
+338,Didi Louzada,22,https://www.basketball-reference.com/req/202106291/images/players/louzama01.jpg,0,2197674.00,2302326.00,TOT
+339,Kevin Love,33,https://www.basketball-reference.com/req/202106291/images/players/loveke01.jpg,5.7,2168760.00,2277000.00,Cleveland Cavaliers
+340,Kyle Lowry,35,https://www.basketball-reference.com/req/202106291/images/players/lowryky01.jpg,6.4,2161440.00,3901399.00,Miami Heat
+341,Gabriel Lundberg,27,https://www.basketball-reference.com/req/202106291/images/players/lundbga01.jpg,0,2161152.00,,Phoenix Suns
+342,Timothé Luwawu-Cabarrot,26,https://www.basketball-reference.com/req/202106291/images/players/luwawti01.jpg,0.9,2145720.00,3873025.00,Atlanta Hawks
+343,Trey Lyles,26,https://www.basketball-reference.com/req/202106291/images/players/lylestr01.jpg,3.5,2137440.00,2239200.00,TOT
+344,Théo Maledon,20,https://www.basketball-reference.com/req/202106291/images/players/maledth01.jpg,0.3,2130240.00,3845083.00,Oklahoma City Thunder
+345,Sandro Mamukelashvili,22,https://www.basketball-reference.com/req/202106291/images/players/mamuksa01.jpg,1.1,2096880.00,2201400.00,Milwaukee Bucks
+346,Terance Mann,25,https://www.basketball-reference.com/req/202106291/images/players/mannte01.jpg,5.5,2089448.00,,Los Angeles Clippers
+347,Tre Mann,20,https://www.basketball-reference.com/req/202106291/images/players/manntr01.jpg,0.1,2089448.00,,Oklahoma City Thunder
+348,Boban Marjanović,33,https://www.basketball-reference.com/req/202106291/images/players/marjabo01.jpg,0.1,2089448.00,,Dallas Mavericks
+349,Lauri Markkanen,24,https://www.basketball-reference.com/req/202106291/images/players/markkla01.jpg,5,2075880.00,2174880.00,Cleveland Cavaliers
+350,Naji Marshall,24,https://www.basketball-reference.com/req/202106291/images/players/marshna01.jpg,0.8,2063280.00,2161440.00,New Orleans Pelicans
+351,Caleb Martin,26,https://www.basketball-reference.com/req/202106291/images/players/martica02.jpg,4,2048040.00,2145720.00,Miami Heat
+352,Cody Martin,26,https://www.basketball-reference.com/req/202106291/images/players/martico01.jpg,3.9,2036280.00,2138160.00,Charlotte Hornets
+353,Kelan Martin,26,https://www.basketball-reference.com/req/202106291/images/players/martike03.jpg,0,2033160.00,2130240.00,TOT
+354,Kenyon Martin Jr.,21,https://www.basketball-reference.com/req/202106291/images/players/martike04.jpg,2.9,2023800.00,2125200.00,Houston Rockets
+355,Garrison Mathews,25,https://www.basketball-reference.com/req/202106291/images/players/mathega01.jpg,2.8,2009040.00,2109360.00,Houston Rockets
+356,Dakota Mathias,26,https://www.basketball-reference.com/req/202106291/images/players/mathida01.jpg,0,2000000.00,2000000.00,Memphis Grizzlies
+357,Wesley Matthews,35,https://www.basketball-reference.com/req/202106291/images/players/matthwe02.jpg,1.2,2000000.00,2000000.00,Milwaukee Bucks
+358,Tyrese Maxey,21,https://www.basketball-reference.com/req/202106291/images/players/maxeyty01.jpg,7.3,2000000.00,,Philadelphia 76ers
+359,Skylar Mays,24,https://www.basketball-reference.com/req/202106291/images/players/mayssk01.jpg,0.3,2000000.00,1900000.00,Atlanta Hawks
+360,Miles McBride,21,https://www.basketball-reference.com/req/202106291/images/players/mcbrimi01.jpg,0.2,2000000.00,2000000.00,New York Knicks
+361,Mac McClung,23,https://www.basketball-reference.com/req/202106291/images/players/mccluma01.jpg,0,1994520.00,2094240.00,TOT
+362,CJ McCollum,30,https://www.basketball-reference.com/req/202106291/images/players/mccolcj01.jpg,3.6,1977011.00,,TOT
+363,T.J. McConnell,29,https://www.basketball-reference.com/req/202106291/images/players/mccontj01.jpg,1.3,1958501.00,,Indiana Pacers
+364,Jaden McDaniels,21,https://www.basketball-reference.com/req/202106291/images/players/mcdanja02.jpg,2.4,1939350.00,,Minnesota Timberwolves
+365,Jalen McDaniels,24,https://www.basketball-reference.com/req/202106291/images/players/mcdanja01.jpg,1.7,2541217.00,,Charlotte Hornets
+366,Doug McDermott,30,https://www.basketball-reference.com/req/202106291/images/players/mcderdo01.jpg,1.6,1939350.00,,San Antonio Spurs
+367,JaVale McGee,34,https://www.basketball-reference.com/req/202106291/images/players/mcgeeja01.jpg,4.9,1939350.00,,Phoenix Suns
+368,Cameron McGriff,24,https://www.basketball-reference.com/req/202106291/images/players/mcgrica01.jpg,0.1,1910860.00,,Portland Trail Blazers
+369,Rodney McGruder,30,https://www.basketball-reference.com/req/202106291/images/players/mcgruro01.jpg,1.2,1910860.00,,Detroit Pistons
+370,Alfonzo McKinnie,29,https://www.basketball-reference.com/req/202106291/images/players/mckinal01.jpg,-0.1,1865547.00,,Chicago Bulls
+371,JaQuori McLaughlin,24,https://www.basketball-reference.com/req/202106291/images/players/mclauja01.jpg,0,1846738.00,1997718.00,Dallas Mavericks
+372,Jordan McLaughlin,25,https://www.basketball-reference.com/req/202106291/images/players/mclaujo01.jpg,2.3,1802057.00,,Minnesota Timberwolves
+373,Ben McLemore,28,https://www.basketball-reference.com/req/202106291/images/players/mclembe01.jpg,0.8,1802057.00,,Portland Trail Blazers
+374,De'Anthony Melton,23,https://www.basketball-reference.com/req/202106291/images/players/meltode01.jpg,3.7,1789256.00,,Memphis Grizzlies
+375,Sam Merrill,25,https://www.basketball-reference.com/req/202106291/images/players/merrisa01.jpg,0,1789256.00,,Memphis Grizzlies
+376,Chimezie Metu,24,https://www.basketball-reference.com/req/202106291/images/players/metuch01.jpg,1.5,1789256.00,,Sacramento Kings
+377,Khris Middleton,30,https://www.basketball-reference.com/req/202106291/images/players/middlkh01.jpg,5.3,1789256.00,2036318.00,Milwaukee Bucks
+378,C.J. Miles,34,https://www.basketball-reference.com/req/202106291/images/players/milescj01.jpg,0,1789256.00,2036318.00,Boston Celtics
+379,Patty Mills,33,https://www.basketball-reference.com/req/202106291/images/players/millspa02.jpg,2.8,1786878.00,1876222.00,Brooklyn Nets
+380,Paul Millsap,36,https://www.basketball-reference.com/req/202106291/images/players/millspa01.jpg,0.5,1782621.00,1930681.00,TOT
+381,Shake Milton,25,https://www.basketball-reference.com/req/202106291/images/players/miltosh01.jpg,1.7,1782621.00,1930681.00,Philadelphia 76ers
+382,Davion Mitchell,23,https://www.basketball-reference.com/req/202106291/images/players/mitchda01.jpg,0.1,1782621.00,,Sacramento Kings
+383,Donovan Mitchell,25,https://www.basketball-reference.com/req/202106291/images/players/mitchdo01.jpg,7.2,1782621.00,,Utah Jazz
+384,Evan Mobley,20,https://www.basketball-reference.com/req/202106291/images/players/mobleev01.jpg,5.2,76744.00,1815677.00,Cleveland Cavaliers
+385,Malik Monk,23,https://www.basketball-reference.com/req/202106291/images/players/monkma01.jpg,3.6,1782621.00,,Los Angeles Lakers
+386,Greg Monroe,31,https://www.basketball-reference.com/req/202106291/images/players/monrogr01.jpg,0.7,1782621.00,,TOT
+387,Moses Moody,19,https://www.basketball-reference.com/req/202106291/images/players/moodymo01.jpg,1.3,1782621.00,,Golden State Warriors
+388,Xavier Moon,27,https://www.basketball-reference.com/req/202106291/images/players/moonxa01.jpg,0.3,1782621.00,1930681.00,Los Angeles Clippers
+389,Matt Mooney,24,https://www.basketball-reference.com/req/202106291/images/players/moonema01.jpg,0,1782621.00,1930681.00,New York Knicks
+390,Ja Morant,22,https://www.basketball-reference.com/req/202106291/images/players/moranja01.jpg,6.7,1782621.00,1930681.00,Memphis Grizzlies
+391,Juwan Morgan,24,https://www.basketball-reference.com/req/202106291/images/players/morgaju01.jpg,0.1,1782621.00,1930681.00,TOT
+392,Jaylen Morris,26,https://www.basketball-reference.com/req/202106291/images/players/morrija01.jpg,-0.1,1782621.00,,San Antonio Spurs
+393,Marcus Morris,32,https://www.basketball-reference.com/req/202106291/images/players/morrima03.jpg,2.4,1782621.00,1930681.00,Los Angeles Clippers
+394,Markieff Morris,32,https://www.basketball-reference.com/req/202106291/images/players/morrima02.jpg,0.3,1782621.00,1930681.00,Miami Heat
+395,Monte Morris,26,https://www.basketball-reference.com/req/202106291/images/players/morrimo01.jpg,5.4,1762796.00,,Denver Nuggets
+396,Emmanuel Mudiay,25,https://www.basketball-reference.com/req/202106291/images/players/mudiaem01.jpg,0,1762796.00,1910860.00,Sacramento Kings
+397,Mychal Mulder,27,https://www.basketball-reference.com/req/202106291/images/players/muldemy01.jpg,-0.2,1762769.00,,TOT
+398,Ade Murkey,24,https://www.basketball-reference.com/req/202106291/images/players/murkead01.jpg,0,1729217.00,1878720.00,Sacramento Kings
+399,Trey Murphy III,21,https://www.basketball-reference.com/req/202106291/images/players/murphtr02.jpg,1.9,1729217.00,1878720.00,New Orleans Pelicans
+400,Dejounte Murray,25,https://www.basketball-reference.com/req/202106291/images/players/murrade01.jpg,7.3,1729217.00,1878720.00,San Antonio Spurs
+401,Mike Muscala,30,https://www.basketball-reference.com/req/202106291/images/players/muscami01.jpg,2.1,1729217.00,1878720.00,Oklahoma City Thunder
+402,Svi Mykhailiuk,24,https://www.basketball-reference.com/req/202106291/images/players/mykhasv01.jpg,0.8,1729217.00,,Toronto Raptors
+403,Abdel Nader,28,https://www.basketball-reference.com/req/202106291/images/players/naderab01.jpg,0,3430810.00,,Phoenix Suns
+404,Larry Nance Jr.,29,https://www.basketball-reference.com/req/202106291/images/players/nancela02.jpg,2.3,1701593.00,,TOT
+405,RJ Nembhard Jr.,22,https://www.basketball-reference.com/req/202106291/images/players/nembhrj01.jpg,0,1720779.00,,Cleveland Cavaliers
+406,Aaron Nesmith,22,https://www.basketball-reference.com/req/202106291/images/players/nesmiaa01.jpg,0.4,1701593.00,1846738.00,Boston Celtics
+407,Raul Neto,29,https://www.basketball-reference.com/req/202106291/images/players/netora01.jpg,1.5,3430810.00,,Washington Wizards
+408,Malik Newman,24,https://www.basketball-reference.com/req/202106291/images/players/newmama01.jpg,0,1700000.00,1785000.00,Cleveland Cavaliers
+409,Georges Niang,28,https://www.basketball-reference.com/req/202106291/images/players/niangge01.jpg,2.8,1690507.00,,Philadelphia 76ers
+410,Daishen Nix,19,https://www.basketball-reference.com/req/202106291/images/players/nixda01.jpg,-0.2,1669178.00,1815677.00,Houston Rockets
+411,Zeke Nnaji,21,https://www.basketball-reference.com/req/202106291/images/players/nnajize01.jpg,1.8,1669178.00,1815677.00,Denver Nuggets
+412,Nerlens Noel,27,https://www.basketball-reference.com/req/202106291/images/players/noelne01.jpg,1.5,1669178.00,1815677.00,New York Knicks
+413,Jaylen Nowell,22,https://www.basketball-reference.com/req/202106291/images/players/nowelja01.jpg,2.8,1669178.00,1815677.00,Minnesota Timberwolves
+414,Frank Ntilikina,23,https://www.basketball-reference.com/req/202106291/images/players/ntilila01.jpg,0.9,1669178.00,,Dallas Mavericks
+415,Jusuf Nurkić,27,https://www.basketball-reference.com/req/202106291/images/players/nurkiju01.jpg,3.6,1669178.00,,Portland Trail Blazers
+416,David Nwaba,29,https://www.basketball-reference.com/req/202106291/images/players/nwabada01.jpg,1.3,1517981.00,1782621.00,Houston Rockets
+417,Jordan Nwora,23,https://www.basketball-reference.com/req/202106291/images/players/nworajo01.jpg,0.6,1517981.00,1782621.00,Milwaukee Bucks
+418,Royce O'Neale,28,https://www.basketball-reference.com/req/202106291/images/players/onealro01.jpg,5.5,1517981.00,1782621.00,Utah Jazz
+419,Semi Ojeleye,27,https://www.basketball-reference.com/req/202106291/images/players/ojelese01.jpg,0.2,1517981.00,1782621.00,TOT
+420,Chuma Okeke,23,https://www.basketball-reference.com/req/202106291/images/players/okekech01.jpg,2.2,1517981.00,,Orlando Magic
+421,Josh Okogie,23,https://www.basketball-reference.com/req/202106291/images/players/okogijo01.jpg,0.7,1517981.00,,Minnesota Timberwolves
+422,Onyeka Okongwu,21,https://www.basketball-reference.com/req/202106291/images/players/okongon01.jpg,4.2,1517981.00,,Atlanta Hawks
+423,Isaac Okoro,21,https://www.basketball-reference.com/req/202106291/images/players/okorois01.jpg,4.2,1517981.00,,Cleveland Cavaliers
+424,KZ Okpala,22,https://www.basketball-reference.com/req/202106291/images/players/okpalkz01.jpg,0.5,1517981.00,1782621.00,Miami Heat
+425,Victor Oladipo,29,https://www.basketball-reference.com/req/202106291/images/players/oladivi01.jpg,0.4,1517981.00,1782621.00,Miami Heat
+426,Cameron Oliver,25,https://www.basketball-reference.com/req/202106291/images/players/oliveca01.jpg,0.2,1517981.00,,Atlanta Hawks
+427,Kelly Olynyk,30,https://www.basketball-reference.com/req/202106291/images/players/olynyke01.jpg,1.6,1517981.00,1782621.00,Detroit Pistons
+428,Eugene Omoruyi,24,https://www.basketball-reference.com/req/202106291/images/players/omorueu01.jpg,0.1,1517981.00,,Dallas Mavericks
+429,Miye Oni,24,https://www.basketball-reference.com/req/202106291/images/players/onimi01.jpg,0,1517981.00,1782621.00,Utah Jazz
+430,Cedi Osman,26,https://www.basketball-reference.com/req/202106291/images/players/osmande01.jpg,2.9,1517981.00,1782621.00,Cleveland Cavaliers
+431,Daniel Oturu,22,https://www.basketball-reference.com/req/202106291/images/players/oturuda01.jpg,0.1,1517981.00,1782621.00,Toronto Raptors
+432,Kelly Oubre Jr.,26,https://www.basketball-reference.com/req/202106291/images/players/oubreke01.jpg,3.3,1517981.00,1782621.00,Charlotte Hornets
+433,Jaysean Paige,27,https://www.basketball-reference.com/req/202106291/images/players/paigeja01.jpg,-0.1,1500000.00,1563518.00,Detroit Pistons
+434,Trayvon Palmer,27,https://www.basketball-reference.com/req/202106291/images/players/palmetr01.jpg,0,1500000.00,1563518.00,Detroit Pistons
+435,Kevin Pangos,29,https://www.basketball-reference.com/req/202106291/images/players/pangoke01.jpg,0.1,1489065.00,1752638.00,Cleveland Cavaliers
+436,Jabari Parker,26,https://www.basketball-reference.com/req/202106291/images/players/parkeja01.jpg,0.3,1489065.00,1752638.00,Boston Celtics
+437,Eric Paschall,25,https://www.basketball-reference.com/req/202106291/images/players/pascher01.jpg,2,1625991.00,1752638.00,Utah Jazz
+438,Chris Paul,36,https://www.basketball-reference.com/req/202106291/images/players/paulch01.jpg,9.4,1456666.00,,Phoenix Suns
+439,Cameron Payne,27,https://www.basketball-reference.com/req/202106291/images/players/payneca01.jpg,1.9,2045094.00,,Phoenix Suns
+440,Elfrid Payton,27,https://www.basketball-reference.com/req/202106291/images/players/paytoel01.jpg,-0.2,1366392.00,,Phoenix Suns
+441,Gary Payton II,29,https://www.basketball-reference.com/req/202106291/images/players/paytoga02.jpg,5.2,4000000.00,4000000.00,Golden State Warriors
+442,Norvel Pelle,28,https://www.basketball-reference.com/req/202106291/images/players/pelleno01.jpg,0,1252127.00,,Utah Jazz
+443,Reggie Perry,21,https://www.basketball-reference.com/req/202106291/images/players/perryre01.jpg,0.2,1250000.00,1563518.00,TOT
+444,Jamorko Pickett,24,https://www.basketball-reference.com/req/202106291/images/players/pickeja01.jpg,0.1,1093598.00,1815677.00,Detroit Pistons
+445,Theo Pinson,26,https://www.basketball-reference.com/req/202106291/images/players/pinsoth01.jpg,0.4,1090007.00,,Dallas Mavericks
+446,Mason Plumlee,31,https://www.basketball-reference.com/req/202106291/images/players/plumlma01.jpg,4.7,1068288.00,,Charlotte Hornets
+447,Jakob Poeltl,26,https://www.basketball-reference.com/req/202106291/images/players/poeltja01.jpg,6.9,1062303.00,1563518.00,San Antonio Spurs
+448,Aleksej Pokusevski,20,https://www.basketball-reference.com/req/202106291/images/players/pokusal01.jpg,0.4,1057260.00,1563518.00,Oklahoma City Thunder
+449,Yves Pons,22,https://www.basketball-reference.com/req/202106291/images/players/ponsyv01.jpg,0,1039080.00,,Memphis Grizzlies
+450,Jordan Poole,22,https://www.basketball-reference.com/req/202106291/images/players/poolejo01.jpg,6,1000000.00,1563518.00,Golden State Warriors
+451,Kevin Porter Jr.,21,https://www.basketball-reference.com/req/202106291/images/players/porteke02.jpg,0.8,10720900.00,,Houston Rockets
+452,Michael Porter Jr.,23,https://www.basketball-reference.com/req/202106291/images/players/portemi01.jpg,-0.2,999200.00,999200.00,Denver Nuggets
+453,Otto Porter Jr.,28,https://www.basketball-reference.com/req/202106291/images/players/porteot01.jpg,4.9,958529.00,2193920.00,Golden State Warriors
+454,Bobby Portis,26,https://www.basketball-reference.com/req/202106291/images/players/portibo01.jpg,5.5,925258.00,1563518.00,Milwaukee Bucks
+455,Kristaps Porziņģis,26,https://www.basketball-reference.com/req/202106291/images/players/porzikr01.jpg,5.6,925258.00,1563518.00,TOT
+456,Micah Potter,23,https://www.basketball-reference.com/req/202106291/images/players/pottemi01.jpg,0,925258.00,1563518.00,Detroit Pistons
+457,Dwight Powell,30,https://www.basketball-reference.com/req/202106291/images/players/poweldw01.jpg,8.2,925258.00,1563518.00,Dallas Mavericks
+458,Myles Powell,24,https://www.basketball-reference.com/req/202106291/images/players/powelmy01.jpg,-0.1,925258.00,1563518.00,Philadelphia 76ers
+459,Norman Powell,28,https://www.basketball-reference.com/req/202106291/images/players/powelno01.jpg,2.8,925258.00,1563518.00,TOT
+460,Joshua Primo,19,https://www.basketball-reference.com/req/202106291/images/players/primojo01.jpg,0,925258.00,1563518.00,San Antonio Spurs
+461,Taurean Prince,27,https://www.basketball-reference.com/req/202106291/images/players/princta02.jpg,2.2,925258.00,1563518.00,Minnesota Timberwolves
+462,Payton Pritchard,24,https://www.basketball-reference.com/req/202106291/images/players/pritcpa01.jpg,3.1,925258.00,1563518.00,Boston Celtics
+463,Trevelin Queen,24,https://www.basketball-reference.com/req/202106291/images/players/queentr01.jpg,0.1,925258.00,1563518.00,Houston Rockets
+464,Neemia Queta,22,https://www.basketball-reference.com/req/202106291/images/players/quetane01.jpg,0.1,925258.00,,Sacramento Kings
+465,Immanuel Quickley,22,https://www.basketball-reference.com/req/202106291/images/players/quickim01.jpg,4.2,925258.00,,New York Knicks
+466,Jahmi'us Ramsey,20,https://www.basketball-reference.com/req/202106291/images/players/ramseja01.jpg,-0.1,924730.00,,Sacramento Kings
+467,Julius Randle,27,https://www.basketball-reference.com/req/202106291/images/players/randlju01.jpg,3.1,888616.00,2351521.00,New York Knicks
+468,Austin Reaves,23,https://www.basketball-reference.com/req/202106291/images/players/reaveau01.jpg,2.9,850331.00,,Los Angeles Lakers
+469,Cam Reddish,22,https://www.basketball-reference.com/req/202106291/images/players/reddica01.jpg,1,785102.00,,TOT
+470,Davon Reed,26,https://www.basketball-reference.com/req/202106291/images/players/reedda01.jpg,1.6,20168742.00,,Denver Nuggets
+471,Paul Reed,22,https://www.basketball-reference.com/req/202106291/images/players/reedpa01.jpg,1.3,705598.00,,Philadelphia 76ers
+472,Naz Reid,22,https://www.basketball-reference.com/req/202106291/images/players/reidna01.jpg,3.2,705598.00,,Minnesota Timberwolves
+473,Nick Richards,24,https://www.basketball-reference.com/req/202106291/images/players/richani01.jpg,1,1290481.00,,Charlotte Hornets
+474,Josh Richardson,28,https://www.basketball-reference.com/req/202106291/images/players/richajo01.jpg,3.5,666666.00,,TOT
+475,Austin Rivers,29,https://www.basketball-reference.com/req/202106291/images/players/riverau01.jpg,1.2,663024.00,,Denver Nuggets
+476,Duncan Robinson,27,https://www.basketball-reference.com/req/202106291/images/players/robindu01.jpg,3.9,2045094.00,,Miami Heat
+477,Justin Robinson,24,https://www.basketball-reference.com/req/202106291/images/players/robinju01.jpg,-0.3,7622467.00,333333.00,TOT
+478,Mitchell Robinson,23,https://www.basketball-reference.com/req/202106291/images/players/robinmi01.jpg,8.5,1290481.00,,New York Knicks
+479,Jeremiah Robinson-Earl,21,https://www.basketball-reference.com/req/202106291/images/players/robinje02.jpg,1.5,606702.00,,Oklahoma City Thunder
+480,Isaiah Roby,23,https://www.basketball-reference.com/req/202106291/images/players/robyis01.jpg,2.9,2541217.00,,Oklahoma City Thunder
+481,Rajon Rondo,35,https://www.basketball-reference.com/req/202106291/images/players/rondora01.jpg,0.7,11109327.00,7827907.00,TOT
+482,Derrick Rose,33,https://www.basketball-reference.com/req/202106291/images/players/rosede01.jpg,1.4,586136.00,,New York Knicks
+483,Terrence Ross,30,https://www.basketball-reference.com/req/202106291/images/players/rosste01.jpg,0.3,558345.00,,Orlando Magic
+484,Terry Rozier,27,https://www.basketball-reference.com/req/202106291/images/players/roziete01.jpg,5.9,527614.00,,Charlotte Hornets
+485,Ricky Rubio,31,https://www.basketball-reference.com/req/202106291/images/players/rubiori01.jpg,1.3,10468119.00,,Cleveland Cavaliers
+486,D'Angelo Russell,25,https://www.basketball-reference.com/req/202106291/images/players/russeda01.jpg,4.4,462629.00,,Minnesota Timberwolves
+487,Matt Ryan,24,https://www.basketball-reference.com/req/202106291/images/players/ryanma01.jpg,0,4107149.00,3925000.00,Boston Celtics
+488,Domantas Sabonis,25,https://www.basketball-reference.com/req/202106291/images/players/sabondo01.jpg,7.1,377645.00,,TOT
+489,Olivier Sarr,22,https://www.basketball-reference.com/req/202106291/images/players/sarrol01.jpg,1,364533.00,,Oklahoma City Thunder
+490,Tomáš Satoranský,30,https://www.basketball-reference.com/req/202106291/images/players/satorto01.jpg,1,350000.00,,TOT
+491,Jordan Schakel,23,https://www.basketball-reference.com/req/202106291/images/players/schakjo01.jpg,-0.1,313737.00,1563518.00,Washington Wizards
+492,Admiral Schofield,24,https://www.basketball-reference.com/req/202106291/images/players/schofad01.jpg,0.3,,,Orlando Magic
+493,Dennis Schröder,28,https://www.basketball-reference.com/req/202106291/images/players/schrode01.jpg,2.9,292466.00,1563518.00,TOT
+494,Tre Scott,25,https://www.basketball-reference.com/req/202106291/images/players/scotttr01.jpg,0,290967.00,1752638.00,Cleveland Cavaliers
+495,Jay Scrubb,21,https://www.basketball-reference.com/req/202106291/images/players/scrubja01.jpg,0,276039.00,,Los Angeles Clippers
+496,Wayne Selden,27,https://www.basketball-reference.com/req/202106291/images/players/seldewa01.jpg,0,260561.00,1563518.00,New York Knicks
+497,Alperen Şengün,19,https://www.basketball-reference.com/req/202106291/images/players/sengual01.jpg,2.1,8558.00,,Houston Rockets
+498,Collin Sexton,23,https://www.basketball-reference.com/req/202106291/images/players/sextoco01.jpg,-0.1,231062.00,1752638.00,Cleveland Cavaliers
+499,Landry Shamet,24,https://www.basketball-reference.com/req/202106291/images/players/shamela01.jpg,2.6,202068.00,,Phoenix Suns
+500,Day'Ron Sharpe,20,https://www.basketball-reference.com/req/202106291/images/players/sharpda01.jpg,1.2,153488.00,,Brooklyn Nets
+501,Pascal Siakam,27,https://www.basketball-reference.com/req/202106291/images/players/siakapa01.jpg,8.1,1366392.00,,Toronto Raptors
+502,Chris Silva,25,https://www.basketball-reference.com/req/202106291/images/players/silvach01.jpg,0.3,1290481.00,,TOT
+503,Marko Simonovic,22,https://www.basketball-reference.com/req/202106291/images/players/simonma01.jpg,0,1290481.00,,Chicago Bulls
+504,Anfernee Simons,22,https://www.basketball-reference.com/req/202106291/images/players/simonan01.jpg,1.9,1290481.00,,Portland Trail Blazers
+505,Zavier Simpson,24,https://www.basketball-reference.com/req/202106291/images/players/simpsza01.jpg,-0.1,924730.00,,Oklahoma City Thunder
+506,Jericho Sims,23,https://www.basketball-reference.com/req/202106291/images/players/simsje01.jpg,1.5,924730.00,,New York Knicks
+507,Deividas Sirvydis,21,https://www.basketball-reference.com/req/202106291/images/players/sirvyde01.jpg,-0.1,924730.00,,Detroit Pistons
+508,Javonte Smart,22,https://www.basketball-reference.com/req/202106291/images/players/smartja01.jpg,-0.2,924730.00,,TOT
+509,Marcus Smart,27,https://www.basketball-reference.com/req/202106291/images/players/smartma01.jpg,5.6,276039.00,,Boston Celtics
+510,Dennis Smith Jr.,24,https://www.basketball-reference.com/req/202106291/images/players/smithde03.jpg,0.4,276039.00,,Portland Trail Blazers
+511,Ish Smith,33,https://www.basketball-reference.com/req/202106291/images/players/smithis01.jpg,0.5,,,TOT
+512,Jalen Smith,21,https://www.basketball-reference.com/req/202106291/images/players/smithja04.jpg,2.8,,,TOT
+513,Xavier Sneed,24,https://www.basketball-reference.com/req/202106291/images/players/sneedxa01.jpg,0,55208.00,,TOT
+514,Tony Snell,30,https://www.basketball-reference.com/req/202106291/images/players/snellto01.jpg,0.4,55208.00,,TOT
+515,Jaden Springer,19,https://www.basketball-reference.com/req/202106291/images/players/sprinja01.jpg,0,55208.00,,Philadelphia 76ers
+516,Cassius Stanley,22,https://www.basketball-reference.com/req/202106291/images/players/stanlca01.jpg,0.1,55208.00,,Detroit Pistons
+517,Nik Stauskas,28,https://www.basketball-reference.com/req/202106291/images/players/stausni01.jpg,0.1,276039.00,,TOT
+518,Lance Stephenson,31,https://www.basketball-reference.com/req/202106291/images/players/stephla01.jpg,0.8,924730.00,,TOT
+519,Lamar Stevens,24,https://www.basketball-reference.com/req/202106291/images/players/stevela01.jpg,1.6,1625991.00,1752638.00,Cleveland Cavaliers
+520,Isaiah Stewart,20,https://www.basketball-reference.com/req/202106291/images/players/stewais01.jpg,3.4,276039.00,,Detroit Pistons
+521,Max Strus,25,https://www.basketball-reference.com/req/202106291/images/players/strusma01.jpg,3.6,122741.00,122741.00,Miami Heat
+522,Jalen Suggs,20,https://www.basketball-reference.com/req/202106291/images/players/suggsja01.jpg,-1.6,888616.00,2351521.00,Orlando Magic
+523,Craig Sword,28,https://www.basketball-reference.com/req/202106291/images/players/swordcr01.jpg,0.1,888616.00,2351521.00,Washington Wizards
+524,Keifer Sykes,28,https://www.basketball-reference.com/req/202106291/images/players/sykeske01.jpg,-0.5,888616.00,2351521.00,Indiana Pacers
+525,Jae'Sean Tate,26,https://www.basketball-reference.com/req/202106291/images/players/tateja01.jpg,3,888616.00,2351521.00,Houston Rockets
+526,Jayson Tatum,23,https://www.basketball-reference.com/req/202106291/images/players/tatumja01.jpg,9.6,958529.00,2193920.00,Boston Celtics
+527,Terry Taylor,22,https://www.basketball-reference.com/req/202106291/images/players/taylote01.jpg,2.4,958529.00,2193920.00,Indiana Pacers
+528,Garrett Temple,35,https://www.basketball-reference.com/req/202106291/images/players/templga01.jpg,0.8,958529.00,2193920.00,New Orleans Pelicans
+529,Emanuel Terry,25,https://www.basketball-reference.com/req/202106291/images/players/terryem01.jpg,-0.1,2045094.00,,Phoenix Suns
+530,Tyrell Terry,21,https://www.basketball-reference.com/req/202106291/images/players/terryty01.jpg,0,2045094.00,,Memphis Grizzlies
+531,Jon Teske,24,https://www.basketball-reference.com/req/202106291/images/players/teskejo01.jpg,0,2045094.00,,Memphis Grizzlies
+532,Daniel Theis,29,https://www.basketball-reference.com/req/202106291/images/players/theisda01.jpg,1.9,2045094.00,,TOT
+533,Brodric Thomas,25,https://www.basketball-reference.com/req/202106291/images/players/thomabr01.jpg,0.1,,,Boston Celtics
+534,Cam Thomas,20,https://www.basketball-reference.com/req/202106291/images/players/thomaca02.jpg,0.8,586136.00,,Brooklyn Nets
+535,Isaiah Thomas,32,https://www.basketball-reference.com/req/202106291/images/players/thomais02.jpg,0.2,586136.00,,TOT
+536,Matt Thomas,27,https://www.basketball-reference.com/req/202106291/images/players/thomama02.jpg,0.6,606702.00,,Chicago Bulls
+537,Klay Thompson,31,https://www.basketball-reference.com/req/202106291/images/players/thompkl01.jpg,1.8,606702.00,,Golden State Warriors
+538,Tristan Thompson,30,https://www.basketball-reference.com/req/202106291/images/players/thomptr01.jpg,1.6,1090007.00,,TOT
+539,JT Thor,19,https://www.basketball-reference.com/req/202106291/images/players/thorjt01.jpg,0.3,1090007.00,,Charlotte Hornets
+540,Matisse Thybulle,24,https://www.basketball-reference.com/req/202106291/images/players/thybuma01.jpg,3.7,1068288.00,,Philadelphia 76ers
+541,Killian Tillie,23,https://www.basketball-reference.com/req/202106291/images/players/tilliki02.jpg,0.6,100000.00,1752638.00,Memphis Grizzlies
+542,Xavier Tillman Sr.,23,https://www.basketball-reference.com/req/202106291/images/players/tillmxa01.jpg,1.8,1762796.00,,Memphis Grizzlies
+543,Isaiah Todd,20,https://www.basketball-reference.com/req/202106291/images/players/toddis01.jpg,-0.2,1762796.00,,Washington Wizards
+544,Obi Toppin,23,https://www.basketball-reference.com/req/202106291/images/players/toppiob01.jpg,3.9,1762796.00,,New York Knicks
+545,Juan Toscano-Anderson,28,https://www.basketball-reference.com/req/202106291/images/players/toscaju01.jpg,2,1762796.00,,Golden State Warriors
+546,Karl-Anthony Towns,26,https://www.basketball-reference.com/req/202106291/images/players/townska01.jpg,10.3,1762796.00,,Minnesota Timberwolves
+547,Gary Trent Jr.,23,https://www.basketball-reference.com/req/202106291/images/players/trentga02.jpg,5.6,705598.00,,Toronto Raptors
+548,P.J. Tucker,36,https://www.basketball-reference.com/req/202106291/images/players/tuckepj01.jpg,5,705598.00,,Miami Heat
+549,Rayjon Tucker,24,https://www.basketball-reference.com/req/202106291/images/players/tuckera01.jpg,0.4,29814.00,1878720.00,TOT
+550,Myles Turner,25,https://www.basketball-reference.com/req/202106291/images/players/turnemy01.jpg,3.1,29814.00,1878720.00,Indiana Pacers
+551,Jonas Valančiūnas,29,https://www.basketball-reference.com/req/202106291/images/players/valanjo01.jpg,7.3,,,New Orleans Pelicans
+552,Denzel Valentine,28,https://www.basketball-reference.com/req/202106291/images/players/valende01.jpg,0.2,705598.00,,TOT
+553,Jarred Vanderbilt,22,https://www.basketball-reference.com/req/202106291/images/players/vandeja01.jpg,6,705598.00,,Minnesota Timberwolves
+554,Fred VanVleet,27,https://www.basketball-reference.com/req/202106291/images/players/vanvlfr01.jpg,6.7,29814.00,1878720.00,Toronto Raptors
+555,Devin Vassell,21,https://www.basketball-reference.com/req/202106291/images/players/vassede01.jpg,3.3,,,San Antonio Spurs
+556,Gabe Vincent,25,https://www.basketball-reference.com/req/202106291/images/players/vincega01.jpg,2.5,29814.00,1878720.00,Miami Heat
+557,Nikola Vučević,31,https://www.basketball-reference.com/req/202106291/images/players/vucevni01.jpg,4.5,,,Chicago Bulls
+558,Dean Wade,25,https://www.basketball-reference.com/req/202106291/images/players/wadede01.jpg,2.3,,,Cleveland Cavaliers
+559,Franz Wagner,20,https://www.basketball-reference.com/req/202106291/images/players/wagnefr01.jpg,4,,,Orlando Magic
+560,Moritz Wagner,24,https://www.basketball-reference.com/req/202106291/images/players/wagnemo01.jpg,2.8,1720779.00,,Orlando Magic
+561,Ish Wainright,27,https://www.basketball-reference.com/req/202106291/images/players/wainris01.jpg,0.6,1720779.00,,Phoenix Suns
+562,Kemba Walker,31,https://www.basketball-reference.com/req/202106291/images/players/walkeke02.jpg,1.8,,,New York Knicks
+563,Lonnie Walker IV,23,https://www.basketball-reference.com/req/202106291/images/players/walkelo01.jpg,1.2,,,San Antonio Spurs
+564,M.J. Walker,23,https://www.basketball-reference.com/req/202106291/images/players/walkemj01.jpg,0,19186.00,1815677.00,Phoenix Suns
+565,Tyrone Wallace,27,https://www.basketball-reference.com/req/202106291/images/players/wallaty01.jpg,-0.1,19186.00,1815677.00,New Orleans Pelicans
+566,Derrick Walton,26,https://www.basketball-reference.com/req/202106291/images/players/waltode01.jpg,-0.2,,,Detroit Pistons
+567,Brad Wanamaker,32,https://www.basketball-reference.com/req/202106291/images/players/wanambr01.jpg,0,850331.00,,TOT
+568,Duane Washington Jr.,21,https://www.basketball-reference.com/req/202106291/images/players/washidu02.jpg,0,,,Indiana Pacers
+569,P.J. Washington,23,https://www.basketball-reference.com/req/202106291/images/players/washipj01.jpg,3.4,28779.00,1815677.00,Charlotte Hornets
+570,YUtah Jazz Watanabe,27,https://www.basketball-reference.com/req/202106291/images/players/watanyu01.jpg,0.7,,,Toronto Raptors
+571,LIndiana Pacersy Waters III,24,https://www.basketball-reference.com/req/202106291/images/players/waterli01.jpg,0.8,28779.00,1815677.00,Oklahoma City Thunder
+572,Tremont Waters,24,https://www.basketball-reference.com/req/202106291/images/players/watertr01.jpg,0,,,TOT
+573,Trendon Watford,21,https://www.basketball-reference.com/req/202106291/images/players/watfotr01.jpg,1.9,,,Portland Trail Blazers
+574,Paul Watson,27,https://www.basketball-reference.com/req/202106291/images/players/watsopa01.jpg,0,92857.00,92857.00,Oklahoma City Thunder
+575,Quinndary Weatherspoon,25,https://www.basketball-reference.com/req/202106291/images/players/weathqu01.jpg,0.2,290967.00,1752638.00,Golden State Warriors
+576,Russell Westbrook,33,https://www.basketball-reference.com/req/202106291/images/players/westbru01.jpg,1.7,290967.00,1752638.00,Los Angeles Lakers
+577,Coby White,21,https://www.basketball-reference.com/req/202106291/images/players/whiteco01.jpg,2.4,290967.00,1752638.00,Chicago Bulls
+578,Derrick White,27,https://www.basketball-reference.com/req/202106291/images/players/whitede01.jpg,5.1,231062.00,1752638.00,TOT
+579,Hassan Whiteside,32,https://www.basketball-reference.com/req/202106291/images/players/whiteha01.jpg,5.8,231062.00,1752638.00,Utah Jazz
+580,Joe Wieskamp,22,https://www.basketball-reference.com/req/202106291/images/players/wieskjo01.jpg,0.1,1625991.00,1752638.00,San Antonio Spurs
+581,Aaron Wiggins,23,https://www.basketball-reference.com/req/202106291/images/players/wiggiaa01.jpg,1.2,1625991.00,1752638.00,Oklahoma City Thunder
+582,Andrew Wiggins,26,https://www.basketball-reference.com/req/202106291/images/players/wiggian01.jpg,5.1,100000.00,1752638.00,Golden State Warriors
+583,Lindell Wigginton,23,https://www.basketball-reference.com/req/202106291/images/players/wiggili01.jpg,0.2,,,Milwaukee Bucks
+584,Brandon Williams,22,https://www.basketball-reference.com/req/202106291/images/players/willibr03.jpg,-0.5,,,Portland Trail Blazers
+585,Grant Williams,23,https://www.basketball-reference.com/req/202106291/images/players/willigr01.jpg,5.1,1517981.00,1782621.00,Boston Celtics
+586,Kenrich Williams,27,https://www.basketball-reference.com/req/202106291/images/players/willike04.jpg,1.8,,,Oklahoma City Thunder
+587,Lou Williams,35,https://www.basketball-reference.com/req/202106291/images/players/willilo02.jpg,0.6,,,Atlanta Hawks
+588,Patrick Williams,20,https://www.basketball-reference.com/req/202106291/images/players/willipa01.jpg,0.9,76744.00,1815677.00,Chicago Bulls
+589,Robert Williams,24,https://www.basketball-reference.com/req/202106291/images/players/williro04.jpg,9.9,58493.00,,Boston Celtics
+590,Ziaire Williams,20,https://www.basketball-reference.com/req/202106291/images/players/willizi02.jpg,2.2,55208.00,,Memphis Grizzlies
+591,D.J. Wilson,25,https://www.basketball-reference.com/req/202106291/images/players/wilsodj01.jpg,0.4,,,Toronto Raptors
+592,Dylan Windler,25,https://www.basketball-reference.com/req/202106291/images/players/windldy01.jpg,0.8,,,Cleveland Cavaliers
+593,Justise Winslow,25,https://www.basketball-reference.com/req/202106291/images/players/winslju01.jpg,0.8,,,TOT
+594,Cassius Winston,23,https://www.basketball-reference.com/req/202106291/images/players/winstca01.jpg,0,,,Washington Wizards
+595,Christian Wood,26,https://www.basketball-reference.com/req/202106291/images/players/woodch01.jpg,4.9,,,Houston Rockets
+596,Robert Woodard II,22,https://www.basketball-reference.com/req/202106291/images/players/woodaro01.jpg,-0.1,,,Sacramento Kings
+597,Delon Wright,29,https://www.basketball-reference.com/req/202106291/images/players/wrighde01.jpg,3.6,,,Atlanta Hawks
+598,McKinley Wright IV,23,https://www.basketball-reference.com/req/202106291/images/players/wrighmc01.jpg,0,,,Minnesota Timberwolves
+599,Moses Wright,23,https://www.basketball-reference.com/req/202106291/images/players/wrighmo01.jpg,0.1,462629.00,,TOT
+600,Gabe York,28,https://www.basketball-reference.com/req/202106291/images/players/yorkga01.jpg,0,,,Indiana Pacers
+601,Thaddeus Young,33,https://www.basketball-reference.com/req/202106291/images/players/youngth01.jpg,2.2,,,TOT
+602,Trae Young,23,https://www.basketball-reference.com/req/202106291/images/players/youngtr01.jpg,10,,,Atlanta Hawks
+603,Omer Yurtseven,23,https://www.basketball-reference.com/req/202106291/images/players/yurtsom01.jpg,2.1,,,Miami Heat
+604,Cody Zeller,29,https://www.basketball-reference.com/req/202106291/images/players/zelleco01.jpg,1.1,,,Portland Trail Blazers
+605,Ivica Zubac,24,https://www.basketball-reference.com/req/202106291/images/players/zubaciv01.jpg,7.2,,,Los Angeles Clippers

--- a/client/data/players.json
+++ b/client/data/players.json
@@ -1,6389 +1,6994 @@
 [{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d810"
+    "$oid": "62850368cd0631716c143ba9"
   },
   "Rk": 1,
-  "Player": "Precious AChicago Bullsuwa\\aChicago Bullsupr01",
+  "Player": "Precious Achiuwa",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/achiupr01.jpg",
   "WS": "2.5",
-  "salary": "$45780966",
-  "projSalary": "$48070014",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "45780966.00",
+  "projSalary": "48070014.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d811"
+    "$oid": "62850368cd0631716c143baa"
   },
   "Rk": 2,
-  "Player": "Steven Adams\\adamsst01",
+  "Player": "Steven Adams",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/adamsst01.jpg",
   "WS": "6.8",
-  "salary": "$44310840",
-  "projSalary": "$47366760",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "44310840.00",
+  "projSalary": "47366760.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d812"
+    "$oid": "62850368cd0631716c143bab"
   },
   "Rk": 3,
-  "Player": "Bam Adebayo\\adebaba01",
+  "Player": "Bam Adebayo",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/adebaba01.jpg",
   "WS": "7.2",
-  "salary": "$44211146",
-  "projSalary": "$47063478",
+  "salary": "44211146.00",
+  "projSalary": "47063478.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d813"
+    "$oid": "62850368cd0631716c143bac"
   },
   "Rk": 4,
-  "Player": "Santi Aldama\\aldamsa01",
+  "Player": "Santi Aldama",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/aldamsa01.jpg",
   "WS": "0.3",
-  "salary": "$43848000",
-  "projSalary": "$46872000",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "43848000.00",
+  "projSalary": "46872000.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d814"
+    "$oid": "62850368cd0631716c143bad"
   },
   "Rk": 5,
-  "Player": "LaMarcus Aldridge\\aldrila01",
+  "Player": "LaMarcus Aldridge",
   "age": 36,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/aldrila01.jpg",
   "WS": "3.1",
-  "salary": "$41180544",
-  "projSalary": "$44474988",
-  "playerTeam": "BRK"
+  "salary": "41180544.00",
+  "projSalary": "44474988.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d815"
+    "$oid": "62850368cd0631716c143bae"
   },
   "Rk": 6,
-  "Player": "Nickeil Alexander-Walker\\alexani01",
+  "Player": "Nickeil Alexander-Walker",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/alexani01.jpg",
   "WS": "0.1",
-  "salary": "$40918900",
-  "projSalary": "$44119845",
+  "salary": "40918900.00",
+  "projSalary": "44119845.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d816"
+    "$oid": "62850368cd0631716c143baf"
   },
   "Rk": 7,
-  "Player": "Grayson Allen\\allengr01",
+  "Player": "Grayson Allen",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/allengr01.jpg",
   "WS": "4.2",
-  "salary": "$39344970",
-  "projSalary": "$42492568",
+  "salary": "39344970.00",
+  "projSalary": "42492568.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d817"
+    "$oid": "62850368cd0631716c143bb0"
   },
   "Rk": 8,
-  "Player": "Jarrett Allen\\allenja01",
+  "Player": "Jarrett Allen",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/allenja01.jpg",
   "WS": "8.5",
-  "salary": "$39344970",
-  "projSalary": "$42492568",
+  "salary": "39344970.00",
+  "projSalary": "42492568.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d818"
+    "$oid": "62850368cd0631716c143bb1"
   },
   "Rk": 9,
-  "Player": "Jose Alvarado\\alvarjo01",
+  "Player": "Jose Alvarado",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/alvarjo01.jpg",
   "WS": "2.1",
-  "salary": "$39344900",
-  "projSalary": "$42492492",
-  "playerTeam": "NOP"
+  "salary": "39344900.00",
+  "projSalary": "42492492.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d819"
+    "$oid": "62850368cd0631716c143bb2"
   },
   "Rk": 10,
-  "Player": "Justin Anderson\\anderju01",
+  "Player": "Justin Anderson",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/anderju01.jpg",
   "WS": "0.4",
-  "salary": "$39344900",
-  "projSalary": "$42492492",
+  "salary": "39344900.00",
+  "projSalary": "42492492.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d81a"
+    "$oid": "62850368cd0631716c143bb3"
   },
   "Rk": 11,
-  "Player": "Kyle Anderson\\anderky01",
+  "Player": "Kyle Anderson",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/anderky01.jpg",
   "WS": "3.5",
-  "salary": "$37980720",
-  "projSalary": "$40600080",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "37980720.00",
+  "projSalary": "40600080.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d81b"
+    "$oid": "62850368cd0631716c143bb4"
   },
   "Rk": 12,
-  "Player": "Giannis Antetokounmpo\\antetgi01",
+  "Player": "Giannis Antetokounmpo",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/antetgi01.jpg",
   "WS": "12.9",
-  "salary": "$36016200",
-  "projSalary": "$37653300",
+  "salary": "36016200.00",
+  "projSalary": "37653300.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d81c"
+    "$oid": "62850368cd0631716c143bb5"
   },
   "Rk": 13,
-  "Player": "Thanasis Antetokounmpo\\antetth01",
+  "Player": "Thanasis Antetokounmpo",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/antetth01.jpg",
   "WS": "0.9",
-  "salary": "$36000000",
-  "projSalary": "$38482759",
+  "salary": "36000000.00",
+  "projSalary": "38482759.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d81d"
+    "$oid": "62850368cd0631716c143bb6"
   },
   "Rk": 14,
-  "Player": "Carmelo Anthony\\anthoca01",
+  "Player": "Carmelo Anthony",
   "age": 37,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/anthoca01.jpg",
   "WS": "3.6",
-  "salary": "$35500000",
-  "projSalary": "$37948276",
+  "salary": "35500000.00",
+  "projSalary": "37948276.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d81e"
+    "$oid": "62850368cd0631716c143bb7"
   },
   "Rk": 15,
-  "Player": "Cole Anthony\\anthoco01",
+  "Player": "Cole Anthony",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/anthoco01.jpg",
   "WS": "1.6",
-  "salary": "$35361360",
-  "projSalary": "$37980720",
+  "salary": "35361360.00",
+  "projSalary": "37980720.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d81f"
+    "$oid": "62850368cd0631716c143bb8"
   },
   "Rk": 16,
-  "Player": "OG Anunoby\\anunoog01",
+  "Player": "OG Anunoby",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/anunoog01.jpg",
   "WS": "3.7",
-  "salary": "$35344828",
-  "projSalary": "$38172414",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "35344828.00",
+  "projSalary": "38172414.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d820"
+    "$oid": "62850368cd0631716c143bb9"
   },
   "Rk": 17,
-  "Player": "Ryan Arcidiacono\\arcidry01",
+  "Player": "Ryan Arcidiacono",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/arcidry01.jpg",
   "WS": "0.1",
-  "salary": "$34916200",
-  "projSalary": "$36503300",
+  "salary": "34916200.00",
+  "projSalary": "36503300.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d821"
+    "$oid": "62850368cd0631716c143bba"
   },
   "Rk": 18,
-  "Player": "Trevor Ariza\\arizatr01",
+  "Player": "Trevor Ariza",
   "age": 36,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/arizatr01.jpg",
   "WS": "0.2",
-  "salary": "$34502130",
-  "projSalary": "$37262300",
+  "salary": "34502130.00",
+  "projSalary": "37262300.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d822"
+    "$oid": "62850368cd0631716c143bbb"
   },
   "Rk": 19,
-  "Player": "D.J. Augustin\\augusdj01",
+  "Player": "D.J. Augustin",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/augusdj01.jpg",
   "WS": "0.8",
-  "salary": "$31650600",
-  "projSalary": "$33833400",
+  "salary": "31650600.00",
+  "projSalary": "33833400.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d823"
+    "$oid": "62850368cd0631716c143bbc"
   },
   "Rk": 20,
-  "Player": "Denver Nuggetsi Avdija\\avdijde01",
+  "Player": "Deni Avdija",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/avdijde01.jpg",
   "WS": "2.4",
-  "salary": "$31610000",
-  "projSalary": "$33790000",
+  "salary": "31610000.00",
+  "projSalary": "33790000.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d824"
+    "$oid": "62850368cd0631716c143bbd"
   },
   "Rk": 21,
-  "Player": "Joel Ayayi\\ayayijo01",
+  "Player": "Joel Ayayi",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ayayijo01.jpg",
   "WS": "0",
-  "salary": "$31610000",
-  "projSalary": "$33790000",
+  "salary": "31610000.00",
+  "projSalary": "33790000.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d825"
+    "$oid": "62850368cd0631716c143bbe"
   },
   "Rk": 22,
-  "Player": "Deandre Ayton\\aytonde01",
+  "Player": "Deandre Ayton",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/aytonde01.jpg",
   "WS": "7.3",
-  "salary": "$31590000",
-  "projSalary": "$33930000",
+  "salary": "31590000.00",
+  "projSalary": "33930000.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d826"
+    "$oid": "62850368cd0631716c143bbf"
   },
   "Rk": 23,
-  "Player": "Udoka Azubuike\\azubuud01",
+  "Player": "Udoka Azubuike",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/azubuud01.jpg",
   "WS": "0.6",
-  "salary": "$31590000",
-  "projSalary": "$33930000",
+  "salary": "31590000.00",
+  "projSalary": "33930000.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d827"
+    "$oid": "62850368cd0631716c143bc0"
   },
   "Rk": 24,
-  "Player": "Marvin Bagley III\\baglema01",
+  "Player": "Marvin Bagley III",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/baglema01.jpg",
   "WS": "2",
-  "salary": "$31579390",
-  "projSalary": "$33616770",
+  "salary": "31579390.00",
+  "projSalary": "33616770.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d828"
+    "$oid": "62850368cd0631716c143bc1"
   },
   "Rk": 25,
-  "Player": "LaMelo Ball\\ballla01",
+  "Player": "LaMelo Ball",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ballla01.jpg",
   "WS": "5.8",
-  "salary": "$31579390",
-  "projSalary": "$33616770",
-  "playerTeam": "CHO"
+  "salary": "31579390.00",
+  "projSalary": "33616770.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d829"
+    "$oid": "62850368cd0631716c143bc2"
   },
   "Rk": 26,
-  "Player": "Lonzo Ball\\balllo01",
+  "Player": "Lonzo Ball",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/balllo01.jpg",
   "WS": "2.2",
-  "salary": "$31320000",
-  "projSalary": "$33640000",
+  "salary": "31320000.00",
+  "projSalary": "33640000.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d82a"
+    "$oid": "62850368cd0631716c143bc3"
   },
   "Rk": 27,
-  "Player": "Mo Bamba\\bambamo01",
+  "Player": "Mo Bamba",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bambamo01.jpg",
   "WS": "4.5",
-  "salary": "$31300000",
-  "projSalary": "$28900000",
+  "salary": "31300000.00",
+  "projSalary": "28900000.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d82b"
+    "$oid": "62850368cd0631716c143bc4"
   },
   "Rk": 28,
-  "Player": "Desmond Bane\\banede01",
+  "Player": "Desmond Bane",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/banede01.jpg",
   "WS": "7.2",
-  "salary": "$30864198",
-  "projSalary": "$33333333",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "30864198.00",
+  "projSalary": "33333333.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d82c"
+    "$oid": "62850368cd0631716c143bc5"
   },
   "Rk": 29,
-  "Player": "Dallas Mavericksano Banton\\bantoda01",
+  "Player": "Dalano Banton",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bantoda01.jpg",
   "WS": "0.4",
-  "salary": "$30800000",
-  "projSalary": "$28400000",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "30800000.00",
+  "projSalary": "28400000.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d82d"
+    "$oid": "62850368cd0631716c143bc6"
   },
   "Rk": 30,
-  "Player": "Cat Barber\\barbeca01",
+  "Player": "Cat Barber",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/barbeca01.jpg",
   "WS": "-0.1",
-  "salary": "$30510423",
-  "projSalary": "$32478837",
+  "salary": "30510423.00",
+  "projSalary": "32478837.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d82e"
+    "$oid": "62850368cd0631716c143bc7"
   },
   "Rk": 31,
-  "Player": "Harrison Barnes\\barneha02",
+  "Player": "Harrison Barnes",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/barneha02.jpg",
   "WS": "6",
-  "salary": "$30133333",
-  "projSalary": "$32393333",
+  "salary": "30133333.00",
+  "projSalary": "32393333.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d82f"
+    "$oid": "62850368cd0631716c143bc8"
   },
   "Rk": 32,
-  "Player": "Scottie Barnes\\barnesc01",
+  "Player": "Scottie Barnes",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/barnesc01.jpg",
   "WS": "6.6",
-  "salary": "$30013500",
-  "projSalary": "$31377750",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "30013500.00",
+  "projSalary": "31377750.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d830"
+    "$oid": "62850368cd0631716c143bc9"
   },
   "Rk": 33,
-  "Player": "RJ Barrett\\barrerj01",
+  "Player": "RJ Barrett",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/barrerj01.jpg",
   "WS": "2.3",
-  "salary": "$29900000",
-  "projSalary": "$30100000",
+  "salary": "29900000.00",
+  "projSalary": "30100000.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d831"
+    "$oid": "62850368cd0631716c143bca"
   },
   "Rk": 34,
-  "Player": "Will Barton\\bartowi01",
+  "Player": "Will Barton",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bartowi01.jpg",
   "WS": "3.2",
-  "salary": "$32405817",
+  "salary": "32405817.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d832"
+    "$oid": "62850368cd0631716c143bcb"
   },
   "Rk": 35,
-  "Player": "Paris Bass\\basspa01",
+  "Player": "Paris Bass",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/basspa01.jpg",
   "WS": "0",
-  "salary": "$29467800",
-  "projSalary": "$31650600",
+  "salary": "29467800.00",
+  "projSalary": "31650600.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d833"
+    "$oid": "62850368cd0631716c143bcc"
   },
   "Rk": 36,
-  "Player": "Charlotte Hornetsrles Bassey\\bassech01",
+  "Player": "Charles Bassey",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bassech01.jpg",
   "WS": "0.8",
-  "salary": "$28103550",
-  "projSalary": "$30351834",
+  "salary": "28103550.00",
+  "projSalary": "30351834.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d834"
+    "$oid": "62850368cd0631716c143bcd"
   },
   "Rk": 37,
-  "Player": "Keita Bates-Diop\\bateske01",
+  "Player": "Keita Bates-Diop",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bateske01.jpg",
   "WS": "1.6",
-  "salary": "$28103550",
-  "projSalary": "$30351834",
+  "salary": "28103550.00",
+  "projSalary": "30351834.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d835"
+    "$oid": "62850368cd0631716c143bce"
   },
   "Rk": 38,
-  "Player": "Nicolas Batum\\batumni01",
+  "Player": "Nicolas Batum",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/batumni01.jpg",
   "WS": "3.7",
-  "salary": "$28103550",
-  "projSalary": "$30351834",
+  "salary": "28103550.00",
+  "projSalary": "30351834.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d836"
+    "$oid": "62850368cd0631716c143bcf"
   },
   "Rk": 39,
-  "Player": "Kent Bazemore\\bazemke01",
+  "Player": "Kent Bazemore",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bazemke01.jpg",
   "WS": "0.1",
-  "salary": "$28103550",
-  "projSalary": "$30351834",
+  "salary": "28103550.00",
+  "projSalary": "30351834.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d837"
+    "$oid": "62850368cd0631716c143bd0"
   },
   "Rk": 40,
-  "Player": "Darius Bazley\\bazleda01",
+  "Player": "Darius Bazley",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bazleda01.jpg",
   "WS": "1.8",
-  "salary": "$27000000",
-  "projSalary": "$26500000",
+  "salary": "27000000.00",
+  "projSalary": "26500000.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d838"
+    "$oid": "62850368cd0631716c143bd1"
   },
   "Rk": 41,
-  "Player": "Bradley Beal\\bealbr01",
+  "Player": "Bradley Beal",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bealbr01.jpg",
   "WS": "1.4",
-  "salary": "$26984128",
-  "projSalary": "$28333334",
+  "salary": "26984128.00",
+  "projSalary": "28333334.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d839"
+    "$oid": "62850368cd0631716c143bd2"
   },
   "Rk": 42,
-  "Player": "Malik Beasley\\beaslma01",
+  "Player": "Malik Beasley",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/beaslma01.jpg",
   "WS": "2.9",
-  "salary": "$34967442",
-  "projSalary": "$36596549",
+  "salary": "34967442.00",
+  "projSalary": "36596549.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d83a"
+    "$oid": "62850368cd0631716c143bd3"
   },
   "Rk": 43,
-  "Player": "Jordan Bell\\belljo01",
+  "Player": "Jordan Bell",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/belljo01.jpg",
   "WS": "0",
-  "salary": "$26000000",
-  "projSalary": "$27300000",
+  "salary": "26000000.00",
+  "projSalary": "27300000.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d83b"
+    "$oid": "62850368cd0631716c143bd4"
   },
   "Rk": 44,
-  "Player": "DeAndre' Bembry\\bembrde01",
+  "Player": "DeAndre' Bembry",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bembrde01.jpg",
   "WS": "2.2",
-  "salary": "$24830357",
-  "projSalary": "$26669643",
+  "salary": "24830357.00",
+  "projSalary": "26669643.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d83c"
+    "$oid": "62850368cd0631716c143bd5"
   },
   "Rk": 45,
-  "Player": "Dāvis Bertāns\\bertada01",
+  "Player": "Dāvis Bertāns",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bertada01.jpg",
   "WS": "0.9",
-  "salary": "$24026712",
-  "projSalary": "$25806469",
+  "salary": "24026712.00",
+  "projSalary": "25806469.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d83d"
+    "$oid": "62850368cd0631716c143bd6"
   },
   "Rk": 46,
-  "Player": "Patrick Beverley\\beverpa01",
+  "Player": "Patrick Beverley",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/beverpa01.jpg",
   "WS": "4.1",
-  "salary": "$24000000",
-  "projSalary": "$22000000",
+  "salary": "24000000.00",
+  "projSalary": "22000000.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d83e"
+    "$oid": "62850368cd0631716c143bd7"
   },
   "Rk": 47,
-  "Player": "Saddiq Bey\\beysa01",
+  "Player": "Saddiq Bey",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/beysa01.jpg",
   "WS": "4",
-  "salary": "$23000000",
-  "projSalary": "$23500000",
+  "salary": "23000000.00",
+  "projSalary": "23500000.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d83f"
+    "$oid": "62850368cd0631716c143bd8"
   },
   "Rk": 48,
-  "Player": "Khem Birch\\birchkh01",
+  "Player": "Khem Birch",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/birchkh01.jpg",
   "WS": "2.6",
-  "salary": "$22477273",
-  "projSalary": "$20522727",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "22477273.00",
+  "projSalary": "20522727.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d840"
+    "$oid": "62850368cd0631716c143bd9"
   },
   "Rk": 49,
-  "Player": "Goga Bitadze\\bitadgo01",
+  "Player": "Goga Bitadze",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bitadgo01.jpg",
   "WS": "1.9",
-  "salary": "$21700000",
-  "projSalary": "$22600000",
+  "salary": "21700000.00",
+  "projSalary": "22600000.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d841"
+    "$oid": "62850368cd0631716c143bda"
   },
   "Rk": 50,
-  "Player": "Bismack Biyombo\\biyombi01",
+  "Player": "Bismack Biyombo",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/biyombi01.jpg",
   "WS": "1.8",
-  "salary": "$21306816",
-  "projSalary": "$19602273",
+  "salary": "21306816.00",
+  "projSalary": "19602273.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d842"
+    "$oid": "62850368cd0631716c143bdb"
   },
   "Rk": 51,
-  "Player": "Nemanja Bjelica\\bjeline01",
+  "Player": "Nemanja Bjelica",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bjeline01.jpg",
   "WS": "3",
-  "salary": "$21000000",
-  "projSalary": "$22680000",
+  "salary": "21000000.00",
+  "projSalary": "22680000.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d843"
+    "$oid": "62850368cd0631716c143bdc"
   },
   "Rk": 52,
-  "Player": "Eric Bledsoe\\bledser01",
+  "Player": "Eric Bledsoe",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bledser01.jpg",
   "WS": "1.3",
-  "salary": "$20482143",
+  "salary": "20482143.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d844"
+    "$oid": "62850368cd0631716c143bdd"
   },
   "Rk": 53,
-  "Player": "Keljin Blevins\\blevike01",
+  "Player": "Keljin Blevins",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/blevike01.jpg",
   "WS": "-0.5",
-  "salary": "$20475000",
-  "projSalary": "$21450000",
+  "salary": "20475000.00",
+  "projSalary": "21450000.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d845"
+    "$oid": "62850368cd0631716c143bde"
   },
   "Rk": 54,
-  "Player": "Bogdan Bogdanović\\bogdabo01",
+  "Player": "Bogdan Bogdanović",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bogdabo01.jpg",
   "WS": "3.7",
-  "salary": "$20284091",
-  "projSalary": "$18352273",
+  "salary": "20284091.00",
+  "projSalary": "18352273.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d846"
+    "$oid": "62850368cd0631716c143bdf"
   },
   "Rk": 55,
-  "Player": "Bojan Bogdanović\\bogdabo02",
+  "Player": "Bojan Bogdanović",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bogdabo02.jpg",
   "WS": "5.2",
-  "salary": "$20000000",
-  "projSalary": "$20000000",
+  "salary": "20000000.00",
+  "projSalary": "20000000.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d847"
+    "$oid": "62850368cd0631716c143be0"
   },
   "Rk": 56,
-  "Player": "Bol Bol\\bolbo01",
+  "Player": "Bol Bol",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bolbo01.jpg",
   "WS": "0.1",
-  "salary": "$20000000",
-  "projSalary": "$20952381",
+  "salary": "20000000.00",
+  "projSalary": "20952381.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d848"
+    "$oid": "62850368cd0631716c143be1"
   },
   "Rk": 57,
-  "Player": "Leandro Bolmaro\\bolmale01",
+  "Player": "Leandro Bolmaro",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bolmale01.jpg",
   "WS": "0",
-  "salary": "$19800000",
-  "projSalary": "$23760000",
+  "salary": "19800000.00",
+  "projSalary": "23760000.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d849"
+    "$oid": "62850368cd0631716c143be2"
   },
   "Rk": 58,
-  "Player": "Isaac Bonga\\bongais01",
+  "Player": "Isaac Bonga",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bongais01.jpg",
   "WS": "0.1",
-  "salary": "$19675926",
-  "projSalary": "$21250000",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "19675926.00",
+  "projSalary": "21250000.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d84a"
+    "$oid": "62850368cd0631716c143be3"
   },
   "Rk": 59,
-  "Player": "Devin Booker\\bookede01",
+  "Player": "Devin Booker",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bookede01.jpg",
   "WS": "7.6",
-  "salary": "$19500000",
+  "salary": "19500000.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d84b"
+    "$oid": "62850368cd0631716c143be4"
   },
   "Rk": 60,
-  "Player": "Brandon Boston Celticston Jr.\\Boston Celticstobr01",
+  "Player": "Brandon Boston Jr.",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bostobr01.jpg",
   "WS": "0.4",
-  "salary": "$20168742",
+  "salary": "20168742.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d84c"
+    "$oid": "62850368cd0631716c143be5"
   },
   "Rk": 61,
-  "Player": "Chris Boucher\\bouchch01",
+  "Player": "Chris Boucher",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bouchch01.jpg",
   "WS": "6",
-  "salary": "$18700000",
-  "projSalary": "$19550000",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "18700000.00",
+  "projSalary": "19550000.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d84d"
+    "$oid": "62850368cd0631716c143be6"
   },
   "Rk": 62,
-  "Player": "James Bouknight\\bouknja01",
+  "Player": "James Bouknight",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bouknja01.jpg",
   "WS": "0",
-  "salary": "$18604651",
-  "projSalary": "$19534884",
-  "playerTeam": "CHO"
+  "salary": "18604651.00",
+  "projSalary": "19534884.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d84e"
+    "$oid": "62850368cd0631716c143be7"
   },
   "Rk": 63,
-  "Player": "Avery Bradley\\bradlav01",
+  "Player": "Avery Bradley",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bradlav01.jpg",
   "WS": "1.2",
-  "salary": "$18562500",
-  "projSalary": "$19937500",
+  "salary": "18562500.00",
+  "projSalary": "19937500.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d84f"
+    "$oid": "62850368cd0631716c143be8"
   },
   "Rk": 64,
-  "Player": "Tony Bradley\\bradlto01",
+  "Player": "Tony Bradley",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bradlto01.jpg",
   "WS": "1.3",
-  "salary": "$18218818",
-  "projSalary": "$19568360",
+  "salary": "18218818.00",
+  "projSalary": "19568360.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d850"
+    "$oid": "62850368cd0631716c143be9"
   },
   "Rk": 65,
-  "Player": "Ignas Brazdeikis\\brazdig01",
+  "Player": "Ignas Brazdeikis",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brazdig01.jpg",
   "WS": "0.5",
-  "salary": "$18139535",
-  "projSalary": "$19046512",
+  "salary": "18139535.00",
+  "projSalary": "19046512.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d851"
+    "$oid": "62850368cd0631716c143bea"
   },
   "Rk": 66,
-  "Player": "Mikal Bridges\\bridgmi01",
+  "Player": "Mikal Bridges",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bridgmi01.jpg",
   "WS": "8.9",
-  "salary": "$18125000",
-  "projSalary": "$19375000",
+  "salary": "18125000.00",
+  "projSalary": "19375000.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d852"
+    "$oid": "62850368cd0631716c143beb"
   },
   "Rk": 67,
-  "Player": "Milwaukee Buckses Bridges\\bridgmi02",
+  "Player": "Miles Bridges",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bridgmi02.jpg",
   "WS": "7.2",
-  "salary": "$18000000",
-  "projSalary": "$18000000",
-  "playerTeam": "CHO"
+  "salary": "18000000.00",
+  "projSalary": "18000000.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d853"
+    "$oid": "62850368cd0631716c143bec"
   },
   "Rk": 68,
-  "Player": "Oshae Brissett\\brissos01",
+  "Player": "Oshae Brissett",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brissos01.jpg",
   "WS": "2.2",
-  "salary": "$18000000",
-  "projSalary": "$18000000",
+  "salary": "18000000.00",
+  "projSalary": "18000000.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d854"
+    "$oid": "62850368cd0631716c143bed"
   },
   "Rk": 69,
-  "Player": "Malcolm Brogdon\\brogdma01",
+  "Player": "Malcolm Brogdon",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brogdma01.jpg",
   "WS": "2.7",
-  "salary": "$17905263",
-  "projSalary": "$21486316",
+  "salary": "17905263.00",
+  "projSalary": "21486316.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d855"
+    "$oid": "62850368cd0631716c143bee"
   },
   "Rk": 70,
-  "Player": "Armoni Brooks\\brookar01",
+  "Player": "Armoni Brooks",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brookar01.jpg",
   "WS": "0.2",
-  "salary": "$17809524",
+  "salary": "17809524.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d856"
+    "$oid": "62850368cd0631716c143bef"
   },
   "Rk": 71,
-  "Player": "Dillon Brooks\\brookdi01",
+  "Player": "Dillon Brooks",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brookdi01.jpg",
   "WS": "1.6",
-  "salary": "$17500000",
-  "projSalary": "$18796296",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "17500000.00",
+  "projSalary": "18796296.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d857"
+    "$oid": "62850368cd0631716c143bf0"
   },
   "Rk": 72,
-  "Player": "Bruce Brown\\brownbr01",
+  "Player": "Bruce Brown",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brownbr01.jpg",
   "WS": "4.8",
-  "salary": "$17400000",
-  "projSalary": "$17400000",
-  "playerTeam": "BRK"
+  "salary": "17400000.00",
+  "projSalary": "17400000.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d858"
+    "$oid": "62850368cd0631716c143bf1"
   },
   "Rk": 73,
-  "Player": "Charlotte Hornetsrlie Brown Jr.\\brownch02",
+  "Player": "Charlie Brown Jr.",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brownch02.jpg",
   "WS": "0",
-  "salary": "$17357143",
-  "projSalary": "$18642857",
+  "salary": "17357143.00",
+  "projSalary": "18642857.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d859"
+    "$oid": "62850368cd0631716c143bf2"
   },
   "Rk": 74,
-  "Player": "Charlotte Hornetsundee Brown Jr.\\brownch05",
+  "Player": "Chaundee Brown Jr.",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brownch05.jpg",
   "WS": "0",
-  "salary": "$17142857",
-  "projSalary": "$18000000",
+  "salary": "17142857.00",
+  "projSalary": "18000000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d85a"
+    "$oid": "62850368cd0631716c143bf3"
   },
   "Rk": 75,
-  "Player": "Greg Brown III\\browngr01",
+  "Player": "Greg Brown III",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/browngr01.jpg",
   "WS": "0.4",
-  "salary": "$17103448",
-  "projSalary": "$18206897",
+  "salary": "17103448.00",
+  "projSalary": "18206897.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d85b"
+    "$oid": "62850368cd0631716c143bf4"
   },
   "Rk": 76,
-  "Player": "Jaylen Brown\\brownja02",
+  "Player": "Jaylen Brown",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brownja02.jpg",
   "WS": "5.8",
-  "salary": "$17073171",
-  "projSalary": "$17926829",
+  "salary": "17073171.00",
+  "projSalary": "17926829.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d85c"
+    "$oid": "62850368cd0631716c143bf5"
   },
   "Rk": 77,
-  "Player": "Moses Brown\\brownmo01",
+  "Player": "Moses Brown",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brownmo01.jpg",
   "WS": "1.2",
-  "salary": "$16500000",
-  "projSalary": "$16500000",
+  "salary": "16500000.00",
+  "projSalary": "16500000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d85d"
+    "$oid": "62850368cd0631716c143bf6"
   },
   "Rk": 78,
-  "Player": "Sterling Brown\\brownst02",
+  "Player": "Sterling Brown",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brownst02.jpg",
   "WS": "0.8",
-  "salary": "$16409091",
-  "projSalary": "$19690909",
+  "salary": "16409091.00",
+  "projSalary": "19690909.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d85e"
+    "$oid": "62850368cd0631716c143bf7"
   },
   "Rk": 79,
-  "Player": "Troy Brown Jr.\\browntr01",
+  "Player": "Troy Brown Jr.",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/browntr01.jpg",
   "WS": "1.4",
-  "salary": "$16071429",
-  "projSalary": "$17357143",
+  "salary": "16071429.00",
+  "projSalary": "17357143.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d85f"
+    "$oid": "62850368cd0631716c143bf8"
   },
   "Rk": 80,
-  "Player": "Jalen Brunson\\brunsja01",
+  "Player": "Jalen Brunson",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/brunsja01.jpg",
   "WS": "7.5",
-  "salary": "$16000000",
-  "projSalary": "$16000000",
+  "salary": "16000000.00",
+  "projSalary": "16000000.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d860"
+    "$oid": "62850368cd0631716c143bf9"
   },
   "Rk": 81,
-  "Player": "Thomas Bryant\\bryanth01",
+  "Player": "Thomas Bryant",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bryanth01.jpg",
   "WS": "1.1",
-  "salary": "$16000000",
-  "projSalary": "$17280000",
+  "salary": "16000000.00",
+  "projSalary": "17280000.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d861"
+    "$oid": "62850368cd0631716c143bfa"
   },
   "Rk": 82,
-  "Player": "Shaq BuCharlotte Hornetsnan\\buCharlotte Hornetssh01",
+  "Player": "Shaq Buchanan",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/buchash01.jpg",
   "WS": "0",
-  "salary": "$15690909",
-  "projSalary": "$16475454",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "15690909.00",
+  "projSalary": "16475454.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d862"
+    "$oid": "62850368cd0631716c143bfb"
   },
   "Rk": 83,
-  "Player": "Reggie Bullock\\bullore01",
+  "Player": "Reggie Bullock",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/bullore01.jpg",
   "WS": "3.2",
-  "salary": "$15627907",
-  "projSalary": "$16372093",
+  "salary": "15627907.00",
+  "projSalary": "16372093.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d863"
+    "$oid": "62850368cd0631716c143bfc"
   },
   "Rk": 84,
-  "Player": "Trey Burke\\burketr01",
+  "Player": "Trey Burke",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/burketr01.jpg",
   "WS": "0",
-  "salary": "$15560000",
-  "projSalary": "$16902000",
+  "salary": "15560000.00",
+  "projSalary": "16902000.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d864"
+    "$oid": "62850368cd0631716c143bfd"
   },
   "Rk": 85,
-  "Player": "Alec Burks\\burksal01",
+  "Player": "Alec Burks",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/burksal01.jpg",
   "WS": "6.1",
-  "salary": "$15517242",
-  "projSalary": "$16758621",
+  "salary": "15517242.00",
+  "projSalary": "16758621.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d865"
+    "$oid": "62850368cd0631716c143bfe"
   },
   "Rk": 86,
-  "Player": "Jared Butler\\butleja02",
+  "Player": "Jared Butler",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/butleja02.jpg",
   "WS": "0.4",
-  "salary": "$15428571",
-  "projSalary": "$16571429",
+  "salary": "15428571.00",
+  "projSalary": "16571429.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d866"
+    "$oid": "62850368cd0631716c143bff"
   },
   "Rk": 87,
-  "Player": "Jimmy Butler\\butleji01",
+  "Player": "Jimmy Butler",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/butleji01.jpg",
   "WS": "9.2",
-  "salary": "$15384615",
-  "projSalary": "$16615385",
+  "salary": "15384615.00",
+  "projSalary": "16615385.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d867"
+    "$oid": "62850368cd0631716c143c00"
   },
   "Rk": 88,
-  "Player": "Devontae Cacok\\cacokde01",
+  "Player": "Devontae Cacok",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cacokde01.jpg",
   "WS": "0.5",
-  "salary": "$15178571",
-  "projSalary": "$16392857",
+  "salary": "15178571.00",
+  "projSalary": "16392857.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d868"
+    "$oid": "62850368cd0631716c143c01"
   },
   "Rk": 89,
-  "Player": "Kentavious Caldwell-Pope\\caldwke01",
+  "Player": "Kentavious Caldwell-Pope",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/caldwke01.jpg",
   "WS": "2.8",
-  "salary": "$15057692",
+  "salary": "15057692.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d869"
+    "$oid": "62850368cd0631716c143c02"
   },
   "Rk": 90,
-  "Player": "Facundo Campazzo\\campafa01",
+  "Player": "Facundo Campazzo",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/campafa01.jpg",
   "WS": "2",
-  "salary": "$14391964",
-  "projSalary": "$15458035",
+  "salary": "14391964.00",
+  "projSalary": "15458035.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d86a"
+    "$oid": "62850368cd0631716c143c03"
   },
   "Rk": 91,
-  "Player": "Vlatko Čančar\\cancavl01",
+  "Player": "Vlatko Čančar",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cancavl01.jpg",
   "WS": "0.4",
-  "salary": "$14339285",
-  "projSalary": "$16607142",
+  "salary": "14339285.00",
+  "projSalary": "16607142.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d86b"
+    "$oid": "62850368cd0631716c143c04"
   },
   "Rk": 92,
-  "Player": "Devin Cannady\\cannade01",
+  "Player": "Devin Cannady",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cannade01.jpg",
   "WS": "0.1",
-  "salary": "$14320988",
-  "projSalary": "$13000000",
+  "salary": "14320988.00",
+  "projSalary": "13000000.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d86c"
+    "$oid": "62850368cd0631716c143c05"
   },
   "Rk": 93,
-  "Player": "Clint Capela\\capelca01",
+  "Player": "Clint Capela",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/capelca01.jpg",
   "WS": "8.3",
-  "salary": "$14190000",
+  "salary": "14190000.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d86d"
+    "$oid": "62850368cd0631716c143c06"
   },
   "Rk": 94,
-  "Player": "Vernon Carey Jr.\\careyve01",
+  "Player": "Vernon Carey Jr.",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/careyve01.jpg",
   "WS": "0.1",
-  "salary": "$14000000",
-  "projSalary": "$14700000",
+  "salary": "14000000.00",
+  "projSalary": "14700000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d86e"
+    "$oid": "62850368cd0631716c143c07"
   },
   "Rk": 95,
-  "Player": "Jevon Carter\\carteje01",
+  "Player": "Jevon Carter",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/carteje01.jpg",
   "WS": "1.2",
-  "salary": "$14000000",
+  "salary": "14000000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d86f"
+    "$oid": "62850368cd0631716c143c08"
   },
   "Rk": 96,
-  "Player": "Wendell Carter Jr.\\cartewe01",
+  "Player": "Wendell Carter Jr.",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cartewe01.jpg",
   "WS": "5",
-  "salary": "$13750000",
-  "projSalary": "$13750000",
+  "salary": "13750000.00",
+  "projSalary": "13750000.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d870"
+    "$oid": "62850368cd0631716c143c09"
   },
   "Rk": 97,
-  "Player": "Alex Caruso\\carusal01",
+  "Player": "Alex Caruso",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/carusal01.jpg",
   "WS": "2",
-  "salary": "$13666667",
-  "projSalary": "$14317459",
+  "salary": "13666667.00",
+  "projSalary": "14317459.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d871"
+    "$oid": "62850368cd0631716c143c0a"
   },
   "Rk": 98,
-  "Player": "Willie Cauley-Stein\\caulewi01",
+  "Player": "Willie Cauley-Stein",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/caulewi01.jpg",
   "WS": "0.2",
-  "salary": "$13445120",
-  "projSalary": "$14520730",
+  "salary": "13445120.00",
+  "projSalary": "14520730.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d872"
+    "$oid": "62850368cd0631716c143c0b"
   },
   "Rk": 99,
-  "Player": "Ahmad Caver\\caverah01",
+  "Player": "Ahmad Caver",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/caverah01.jpg",
   "WS": "0",
-  "salary": "$13302325",
-  "projSalary": "$13906976",
+  "salary": "13302325.00",
+  "projSalary": "13906976.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d873"
+    "$oid": "62850368cd0631716c143c0c"
   },
   "Rk": 100,
-  "Player": "Justin Charlotte Hornetsmpagnie\\Charlotte Hornetsmpju01",
+  "Player": "Justin Champagnie",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/champju01.jpg",
   "WS": "0.8",
-  "salary": "$13038862",
-  "projSalary": "$14004703",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "13038862.00",
+  "projSalary": "14004703.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d874"
+    "$oid": "62850368cd0631716c143c0d"
   },
   "Rk": 101,
-  "Player": "Zylan Cheatham\\cheatzy01",
+  "Player": "Zylan Cheatham",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cheatzy01.jpg",
   "WS": "-0.1",
-  "salary": "$13000000",
-  "projSalary": "$13000000",
+  "salary": "13000000.00",
+  "projSalary": "13000000.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d875"
+    "$oid": "62850368cd0631716c143c0e"
   },
   "Rk": 102,
-  "Player": "Chris Chicago Bullsozza\\Chicago Bullsozch01",
+  "Player": "Chris Chiozza",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/chiozch01.jpg",
   "WS": "0",
-  "salary": "$12975471",
+  "salary": "12975471.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d876"
+    "$oid": "62850368cd0631716c143c0f"
   },
   "Rk": 103,
-  "Player": "Marquese Chriss\\chrisma01",
+  "Player": "Marquese Chriss",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/chrisma01.jpg",
   "WS": "0.8",
-  "salary": "$12727273",
-  "projSalary": "$13745455",
+  "salary": "12727273.00",
+  "projSalary": "13745455.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d877"
+    "$oid": "62850368cd0631716c143c10"
   },
   "Rk": 104,
-  "Player": "Josh Christopher\\chrisjo01",
+  "Player": "Josh Christopher",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/chrisjo01.jpg",
   "WS": "0.3",
-  "salary": "$12690000",
+  "salary": "12690000.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d878"
+    "$oid": "62850368cd0631716c143c11"
   },
   "Rk": 105,
-  "Player": "Gary Clark\\clarkga01",
+  "Player": "Gary Clark",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/clarkga01.jpg",
   "WS": "0.7",
-  "salary": "$12632950",
-  "playerTeam": "NOP"
+  "salary": "12632950.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d879"
+    "$oid": "62850368cd0631716c143c12"
   },
   "Rk": 106,
-  "Player": "Brandon Clarke\\clarkbr01",
+  "Player": "Brandon Clarke",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/clarkbr01.jpg",
   "WS": "6.3",
-  "salary": "$12500000",
-  "projSalary": "$11500000",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "12500000.00",
+  "projSalary": "11500000.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d87a"
+    "$oid": "62850368cd0631716c143c13"
   },
   "Rk": 107,
-  "Player": "Jordan Clarkson\\clarkjo01",
+  "Player": "Jordan Clarkson",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/clarkjo01.jpg",
   "WS": "3.5",
-  "salary": "$12420000",
-  "projSalary": "$13340000",
+  "salary": "12420000.00",
+  "projSalary": "13340000.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d87b"
+    "$oid": "62850368cd0631716c143c14"
   },
   "Rk": 108,
-  "Player": "Nic Claxton\\claxtni01",
+  "Player": "Nic Claxton",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/claxtni01.jpg",
   "WS": "3.5",
-  "salary": "$12200000",
-  "projSalary": "$11400000",
-  "playerTeam": "BRK"
+  "salary": "12200000.00",
+  "projSalary": "11400000.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d87c"
+    "$oid": "62850368cd0631716c143c15"
   },
   "Rk": 109,
-  "Player": "Amir Coffey\\coffeam01",
+  "Player": "Amir Coffey",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/coffeam01.jpg",
   "WS": "3.8",
-  "salary": "$12195122",
-  "projSalary": "$12804878",
+  "salary": "12195122.00",
+  "projSalary": "12804878.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d87d"
+    "$oid": "62850368cd0631716c143c16"
   },
   "Rk": 110,
-  "Player": "John Collins\\collijo01",
+  "Player": "John Collins",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/collijo01.jpg",
   "WS": "5.1",
-  "salary": "$12000000",
-  "projSalary": "$12600000",
+  "salary": "12000000.00",
+  "projSalary": "12600000.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d87e"
+    "$oid": "62850368cd0631716c143c17"
   },
   "Rk": 111,
-  "Player": "Zach Collins\\colliza01",
+  "Player": "Zach Collins",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/colliza01.jpg",
   "WS": "1.2",
-  "salary": "$12000000",
-  "projSalary": "$12960000",
+  "salary": "12000000.00",
+  "projSalary": "12960000.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d87f"
+    "$oid": "62850368cd0631716c143c18"
   },
   "Rk": 112,
-  "Player": "Darren Collison\\collida01",
+  "Player": "Darren Collison",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/collida01.jpg",
   "WS": "-0.1",
-  "salary": "$12000000",
+  "salary": "12000000.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d880"
+    "$oid": "62850368cd0631716c143c19"
   },
   "Rk": 113,
-  "Player": "Mike Conley\\conlemi01",
+  "Player": "Mike Conley",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/conlemi01.jpg",
   "WS": "6.7",
-  "salary": "$11615328",
-  "projSalary": "$12196094",
+  "salary": "11615328.00",
+  "projSalary": "12196094.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d881"
+    "$oid": "62850368cd0631716c143c1a"
   },
   "Rk": 114,
-  "Player": "Pat Connaughton\\connapa01",
+  "Player": "Pat Connaughton",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/connapa01.jpg",
   "WS": "4.4",
-  "salary": "$11312114",
+  "salary": "11312114.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d882"
+    "$oid": "62850368cd0631716c143c1b"
   },
   "Rk": 115,
-  "Player": "Tyler Cook\\cookty01",
+  "Player": "Tyler Cook",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cookty01.jpg",
   "WS": "0.5",
-  "salary": "$11000000",
-  "projSalary": "$11550000",
+  "salary": "11000000.00",
+  "projSalary": "11550000.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d883"
+    "$oid": "62850368cd0631716c143c1c"
   },
   "Rk": 116,
-  "Player": "Sharife Cooper\\coopesh01",
+  "Player": "Sharife Cooper",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/coopesh01.jpg",
   "WS": "-0.2",
-  "salary": "$11000000",
-  "projSalary": "$11814815",
+  "salary": "11000000.00",
+  "projSalary": "11814815.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d884"
+    "$oid": "62850368cd0631716c143c1d"
   },
   "Rk": 117,
-  "Player": "Petr Cornelie\\cornepe01",
+  "Player": "Petr Cornelie",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cornepe01.jpg",
   "WS": "0",
-  "salary": "$10733400",
-  "projSalary": "$13534817",
+  "salary": "10733400.00",
+  "projSalary": "13534817.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d885"
+    "$oid": "62850368cd0631716c143c1e"
   },
   "Rk": 118,
-  "Player": "DeMarcus Cousins\\couside01",
+  "Player": "DeMarcus Cousins",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/couside01.jpg",
   "WS": "1.6",
-  "salary": "$10690909",
-  "projSalary": "$9672727",
+  "salary": "10690909.00",
+  "projSalary": "9672727.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d886"
+    "$oid": "62850368cd0631716c143c1f"
   },
   "Rk": 119,
-  "Player": "Robert Covington\\covinro01",
+  "Player": "Robert Covington",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/covinro01.jpg",
   "WS": "3.2",
-  "salary": "$10500000",
+  "salary": "10500000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d887"
+    "$oid": "62850368cd0631716c143c20"
   },
   "Rk": 120,
-  "Player": "Toronto Raptorssrey Craig\\craigto01",
+  "Player": "Torrey Craig",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/craigto01.jpg",
   "WS": "2.3",
-  "salary": "$10384500",
-  "projSalary": "$11215260",
+  "salary": "10384500.00",
+  "projSalary": "11215260.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d888"
+    "$oid": "62850368cd0631716c143c21"
   },
   "Rk": 121,
-  "Player": "Jae Crowder\\crowdja01",
+  "Player": "Jae Crowder",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/crowdja01.jpg",
   "WS": "4.3",
-  "salary": "$10384500",
-  "projSalary": "$11215260",
+  "salary": "10384500.00",
+  "projSalary": "11215260.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d889"
+    "$oid": "62850368cd0631716c143c22"
   },
   "Rk": 122,
-  "Player": "Jarrett Culver\\culveja01",
+  "Player": "Jarrett Culver",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/culveja01.jpg",
   "WS": "0.1",
-  "salary": "$10245480",
-  "projSalary": "$10733400",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "10245480.00",
+  "projSalary": "10733400.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d88a"
+    "$oid": "62850368cd0631716c143c23"
   },
   "Rk": 123,
-  "Player": "Jarron Cumberland\\cumbeja01",
+  "Player": "Jarron Cumberland",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cumbeja01.jpg",
   "WS": "0",
-  "salary": "$10174391",
-  "projSalary": "$35700000",
+  "salary": "10174391.00",
+  "projSalary": "35700000.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d88b"
+    "$oid": "62850368cd0631716c143c24"
   },
   "Rk": 124,
-  "Player": "Cade Cunningham\\cunnica01",
+  "Player": "Cade Cunningham",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/cunnica01.jpg",
   "WS": "-0.5",
-  "salary": "$10050120",
-  "projSalary": "$10552800",
+  "salary": "10050120.00",
+  "projSalary": "10552800.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d88c"
+    "$oid": "62850368cd0631716c143c25"
   },
   "Rk": 125,
-  "Player": "Seth Curry\\curryse01",
+  "Player": "Seth Curry",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/curryse01.jpg",
   "WS": "4.2",
-  "salary": "$10468119",
+  "salary": "10468119.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d88d"
+    "$oid": "62850368cd0631716c143c26"
   },
   "Rk": 126,
-  "Player": "Stephen Curry\\curryst01",
+  "Player": "Stephen Curry",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/curryst01.jpg",
   "WS": "8",
-  "salary": "$10000000",
-  "projSalary": "$10000000",
+  "salary": "10000000.00",
+  "projSalary": "10000000.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d88e"
+    "$oid": "62850368cd0631716c143c27"
   },
   "Rk": 127,
-  "Player": "Anthony Davis\\davisan02",
+  "Player": "Anthony Davis",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/davisan02.jpg",
   "WS": "4.5",
-  "salary": "$9937150",
+  "salary": "9937150.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d88f"
+    "$oid": "62850368cd0631716c143c28"
   },
   "Rk": 128,
-  "Player": "Ed Davis\\davised01",
+  "Player": "Ed Davis",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/davised01.jpg",
   "WS": "0.5",
-  "salary": "$9742000",
+  "salary": "9742000.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d890"
+    "$oid": "62850368cd0631716c143c29"
   },
   "Rk": 129,
-  "Player": "Terence Davis\\daviste02",
+  "Player": "Terence Davis",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/daviste02.jpg",
   "WS": "0.5",
-  "salary": "$9720900",
-  "projSalary": "$10183800",
+  "salary": "9720900.00",
+  "projSalary": "10183800.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d891"
+    "$oid": "62850368cd0631716c143c2a"
   },
   "Rk": 130,
-  "Player": "Gabriel Deck\\deckga01",
+  "Player": "Gabriel Deck",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/deckga01.jpg",
   "WS": "0.1",
-  "salary": "$9720900",
-  "projSalary": "$10183800",
+  "salary": "9720900.00",
+  "projSalary": "10183800.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d892"
+    "$oid": "62850368cd0631716c143c2b"
   },
   "Rk": 131,
-  "Player": "Dewayne Dedmon\\dedmode01",
+  "Player": "Dewayne Dedmon",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dedmode01.jpg",
   "WS": "3.5",
-  "salary": "$10720900",
+  "salary": "10720900.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d893"
+    "$oid": "62850368cd0631716c143c2c"
   },
   "Rk": 132,
-  "Player": "Sam Dekker\\dekkesa01",
+  "Player": "Sam Dekker",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dekkesa01.jpg",
   "WS": "0",
-  "salary": "$9720900",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "9720900.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d894"
+    "$oid": "62850368cd0631716c143c2d"
   },
   "Rk": 133,
-  "Player": "Javin DeLaurier\\delauja01",
+  "Player": "Javin DeLaurier",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/delauja01.jpg",
   "WS": "0",
-  "salary": "$9720900",
+  "salary": "9720900.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d895"
+    "$oid": "62850368cd0631716c143c2e"
   },
   "Rk": 134,
-  "Player": "DeMar DeRozan\\derozde01",
+  "Player": "DeMar DeRozan",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/derozde01.jpg",
   "WS": "8.8",
-  "salary": "$9603360",
-  "projSalary": "$12119440",
+  "salary": "9603360.00",
+  "projSalary": "12119440.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d896"
+    "$oid": "62850368cd0631716c143c2f"
   },
   "Rk": 135,
-  "Player": "Mamadi Diakite\\diakima01",
+  "Player": "Mamadi Diakite",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/diakima01.jpg",
   "WS": "0.3",
-  "salary": "$9536000",
-  "projSalary": "$10012800",
+  "salary": "9536000.00",
+  "projSalary": "10012800.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d897"
+    "$oid": "62850368cd0631716c143c30"
   },
   "Rk": 136,
-  "Player": "Cheick Diallo\\diallch01",
+  "Player": "Cheick Diallo",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/diallch01.jpg",
   "WS": "0.1",
-  "salary": "$9536000",
-  "projSalary": "$10012800",
+  "salary": "9536000.00",
+  "projSalary": "10012800.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d898"
+    "$oid": "62850368cd0631716c143c31"
   },
   "Rk": 137,
-  "Player": "Hamidou Diallo\\diallha01",
+  "Player": "Hamidou Diallo",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/diallha01.jpg",
   "WS": "2.1",
-  "salary": "$9500000",
-  "projSalary": "$10260000",
+  "salary": "9500000.00",
+  "projSalary": "10260000.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d899"
+    "$oid": "62850368cd0631716c143c32"
   },
   "Rk": 138,
-  "Player": "Gorgui Dieng\\dienggo01",
+  "Player": "Gorgui Dieng",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dienggo01.jpg",
   "WS": "1.2",
-  "salary": "$9180560",
-  "projSalary": "$23437500",
+  "salary": "9180560.00",
+  "projSalary": "23437500.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d89a"
+    "$oid": "62850368cd0631716c143c33"
   },
   "Rk": 139,
-  "Player": "Spencer Dinwiddie\\dinwisp01",
+  "Player": "Spencer Dinwiddie",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dinwisp01.jpg",
   "WS": "4.1",
-  "salary": "$9166800",
-  "projSalary": "$9603360",
+  "salary": "9166800.00",
+  "projSalary": "9603360.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d89b"
+    "$oid": "62850368cd0631716c143c34"
   },
   "Rk": 140,
-  "Player": "Donte DiVincenzo\\divIndiana Pacerso01",
+  "Player": "Donte DiVincenzo",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/divindo01.jpg",
   "WS": "0.7",
-  "salary": "$12213507",
-  "projSalary": "$12372008",
+  "salary": "12213507.00",
+  "projSalary": "12372008.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d89c"
+    "$oid": "62850368cd0631716c143c35"
   },
   "Rk": 141,
-  "Player": "Luka Dončić\\doncilu01",
+  "Player": "Luka Dončić",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/doncilu01.jpg",
   "WS": "7.6",
-  "salary": "$9000000",
-  "projSalary": "$9666667",
+  "salary": "9000000.00",
+  "projSalary": "9666667.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d89d"
+    "$oid": "62850368cd0631716c143c36"
   },
   "Rk": 142,
-  "Player": "Luguentz Dort\\dortlu01",
+  "Player": "Luguentz Dort",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dortlu01.jpg",
   "WS": "1.4",
-  "salary": "$8992200",
-  "projSalary": "$9441720",
+  "salary": "8992200.00",
+  "projSalary": "9441720.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d89e"
+    "$oid": "62850368cd0631716c143c37"
   },
   "Rk": 143,
-  "Player": "Ayo Dosunmu\\dosunay01",
+  "Player": "Ayo Dosunmu",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dosunay01.jpg",
   "WS": "3",
-  "salary": "$8800000",
-  "projSalary": "$9240000",
+  "salary": "8800000.00",
+  "projSalary": "9240000.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d89f"
+    "$oid": "62850368cd0631716c143c38"
   },
   "Rk": 144,
-  "Player": "Damyean Dotson\\dotsoda01",
+  "Player": "Damyean Dotson",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dotsoda01.jpg",
   "WS": "0",
-  "salary": "$8750000",
-  "projSalary": "$9398148",
+  "salary": "8750000.00",
+  "projSalary": "9398148.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a0"
+    "$oid": "62850368cd0631716c143c39"
   },
   "Rk": 145,
-  "Player": "Devon Dotson\\dotsode01",
+  "Player": "Devon Dotson",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dotsode01.jpg",
   "WS": "0.1",
-  "salary": "$8750000",
-  "projSalary": "$9000000",
+  "salary": "8750000.00",
+  "projSalary": "9000000.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a1"
+    "$oid": "62850368cd0631716c143c3a"
   },
   "Rk": 146,
-  "Player": "Sekou Doumbouya\\doumbse01",
+  "Player": "Sekou Doumbouya",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/doumbse01.jpg",
   "WS": "0.1",
-  "salary": "$8730159",
+  "salary": "8730159.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a2"
+    "$oid": "62850368cd0631716c143c3b"
   },
   "Rk": 147,
-  "Player": "Jeff Dowtin\\dowtije01",
+  "Player": "Jeff Dowtin",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dowtije01.jpg",
   "WS": "0",
-  "salary": "$34967442",
-  "projSalary": "$36596549",
+  "salary": "34967442.00",
+  "projSalary": "36596549.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a3"
+    "$oid": "62850368cd0631716c143c3c"
   },
   "Rk": 148,
-  "Player": "PJ Dozier\\doziepj01",
+  "Player": "PJ Dozier",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/doziepj01.jpg",
   "WS": "0.3",
-  "salary": "$8678571",
-  "projSalary": "$9321429",
+  "salary": "8678571.00",
+  "projSalary": "9321429.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a4"
+    "$oid": "62850368cd0631716c143c3d"
   },
   "Rk": 149,
-  "Player": "Goran Dragić\\dragigo01",
+  "Player": "Goran Dragić",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dragigo01.jpg",
   "WS": "0.4",
-  "salary": "$8623920",
-  "projSalary": "$10900635",
+  "salary": "8623920.00",
+  "projSalary": "10900635.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a5"
+    "$oid": "62850368cd0631716c143c3e"
   },
   "Rk": 150,
-  "Player": "Andre Drummond\\drumman01",
+  "Player": "Andre Drummond",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/drumman01.jpg",
   "WS": "5.1",
-  "salary": "$8604651",
-  "projSalary": "$9034884",
+  "salary": "8604651.00",
+  "projSalary": "9034884.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a6"
+    "$oid": "62850368cd0631716c143c3f"
   },
   "Rk": 151,
-  "Player": "Chris Duarte\\duartch01",
+  "Player": "Chris Duarte",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/duartch01.jpg",
   "WS": "0.9",
-  "salary": "$8526316",
+  "salary": "8526316.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a7"
+    "$oid": "62850368cd0631716c143c40"
   },
   "Rk": 152,
-  "Player": "David Duke Jr.\\dukeda01",
+  "Player": "David Duke Jr.",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dukeda01.jpg",
   "WS": "0.3",
-  "salary": "$8437500",
-  "projSalary": "$9062500",
-  "playerTeam": "BRK"
+  "salary": "8437500.00",
+  "projSalary": "9062500.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a8"
+    "$oid": "62850368cd0631716c143c41"
   },
   "Rk": 153,
-  "Player": "Kris Dunn\\dunnkr01",
+  "Player": "Kris Dunn",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/dunnkr01.jpg",
   "WS": "0.2",
-  "salary": "$8372093",
-  "projSalary": "$8790698",
+  "salary": "8372093.00",
+  "projSalary": "8790698.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8a9"
+    "$oid": "62850368cd0631716c143c42"
   },
   "Rk": 154,
-  "Player": "Kevin Durant\\duranke01",
+  "Player": "Kevin Durant",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/duranke01.jpg",
   "WS": "8.4",
-  "salary": "$8333333",
-  "projSalary": "$9000000",
-  "playerTeam": "BRK"
+  "salary": "8333333.00",
+  "projSalary": "9000000.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8aa"
+    "$oid": "62850368cd0631716c143c43"
   },
   "Rk": 155,
-  "Player": "Jaime Echenique\\echenja01",
+  "Player": "Jaime Echenique",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/echenja01.jpg",
   "WS": "0",
-  "salary": "$8326471",
-  "projSalary": "$29750000",
+  "salary": "8326471.00",
+  "projSalary": "29750000.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ab"
+    "$oid": "62850368cd0631716c143c44"
   },
   "Rk": 156,
-  "Player": "Anthony Edwards\\edwaran01",
+  "Player": "Anthony Edwards",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/edwaran01.jpg",
   "WS": "4.3",
-  "salary": "$8292683",
-  "projSalary": "$8707317",
+  "salary": "8292683.00",
+  "projSalary": "8707317.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ac"
+    "$oid": "62850368cd0631716c143c45"
   },
   "Rk": 157,
-  "Player": "Carsen Edwards\\edwarca01",
+  "Player": "Carsen Edwards",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/edwarca01.jpg",
   "WS": "-0.1",
-  "salary": "$8231760",
-  "projSalary": "$8623920",
+  "salary": "8231760.00",
+  "projSalary": "8623920.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ad"
+    "$oid": "62850368cd0631716c143c46"
   },
   "Rk": 158,
-  "Player": "Kessler Edwards\\edwarke02",
+  "Player": "Kessler Edwards",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/edwarke02.jpg",
   "WS": "0.6",
-  "salary": "$8186047",
-  "projSalary": "$8558140",
-  "playerTeam": "BRK"
+  "salary": "8186047.00",
+  "projSalary": "8558140.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ae"
+    "$oid": "62850368cd0631716c143c47"
   },
   "Rk": 159,
-  "Player": "Rob Edwards\\edwarro01",
+  "Player": "Rob Edwards",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/edwarro01.jpg",
   "WS": "0",
-  "salary": "$8137500",
-  "projSalary": "$8525000",
+  "salary": "8137500.00",
+  "projSalary": "8525000.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8af"
+    "$oid": "62850368cd0631716c143c48"
   },
   "Rk": 160,
-  "Player": "CJ Elleby\\ellebcj01",
+  "Player": "CJ Elleby",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ellebcj01.jpg",
   "WS": "0.4",
-  "salary": "$8075160",
-  "projSalary": "$8478720",
+  "salary": "8075160.00",
+  "projSalary": "8478720.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b0"
+    "$oid": "62850368cd0631716c143c49"
   },
   "Rk": 161,
-  "Player": "Wayne Ellington\\ellinwa01",
+  "Player": "Wayne Ellington",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ellinwa01.jpg",
   "WS": "1",
-  "salary": "$8050000",
-  "projSalary": "$7350000",
+  "salary": "8050000.00",
+  "projSalary": "7350000.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b1"
+    "$oid": "62850368cd0631716c143c4a"
   },
   "Rk": 162,
-  "Player": "Joel Embiid\\embiijo01",
+  "Player": "Joel Embiid",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/embiijo01.jpg",
   "WS": "12",
-  "salary": "$11109327",
-  "projSalary": "$7827907",
+  "salary": "11109327.00",
+  "projSalary": "7827907.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b2"
+    "$oid": "62850368cd0631716c143c4b"
   },
   "Rk": 163,
-  "Player": "James Ennis III\\ennisja01",
+  "Player": "James Ennis III",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ennisja01.jpg",
   "WS": "0.1",
-  "salary": "$7775400",
-  "projSalary": "$9835881",
+  "salary": "7775400.00",
+  "projSalary": "9835881.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b3"
+    "$oid": "62850368cd0631716c143c4c"
   },
   "Rk": 164,
-  "Player": "Drew Eubanks\\eubandr01",
+  "Player": "Drew Eubanks",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/eubandr01.jpg",
   "WS": "3.4",
-  "salary": "$7568742",
+  "salary": "7568742.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b4"
+    "$oid": "62850368cd0631716c143c4d"
   },
   "Rk": 165,
-  "Player": "Tacko Fall\\fallta01",
+  "Player": "Tacko Fall",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/fallta01.jpg",
   "WS": "0.1",
-  "salary": "$7522200",
+  "salary": "7522200.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b5"
+    "$oid": "62850368cd0631716c143c4e"
   },
   "Rk": 166,
-  "Player": "Derrick Favors\\favorde01",
+  "Player": "Derrick Favors",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/favorde01.jpg",
   "WS": "1.4",
-  "salary": "$7518518",
-  "projSalary": "$7518518",
+  "salary": "7518518.00",
+  "projSalary": "7518518.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b6"
+    "$oid": "62850368cd0631716c143c4f"
   },
   "Rk": 167,
-  "Player": "Bruno Fernando\\fernabr01",
+  "Player": "Bruno Fernando",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/fernabr01.jpg",
   "WS": "0.4",
-  "salary": "$7500000",
-  "projSalary": "$8100000",
+  "salary": "7500000.00",
+  "projSalary": "8100000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b7"
+    "$oid": "62850368cd0631716c143c50"
   },
   "Rk": 168,
-  "Player": "Dorian Finney-Smith\\finnedo01",
+  "Player": "Dorian Finney-Smith",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/finnedo01.jpg",
   "WS": "6.6",
-  "salary": "$7422000",
-  "projSalary": "$7775400",
+  "salary": "7422000.00",
+  "projSalary": "7775400.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b8"
+    "$oid": "62850368cd0631716c143c51"
   },
   "Rk": 169,
-  "Player": "Malik Fitts\\fittsma01",
+  "Player": "Malik Fitts",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/fittsma01.jpg",
   "WS": "0.1",
-  "salary": "$7280520",
-  "projSalary": "$7644720",
+  "salary": "7280520.00",
+  "projSalary": "7644720.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8b9"
+    "$oid": "62850368cd0631716c143c52"
   },
   "Rk": 170,
-  "Player": "MaLos Angeles Clippershicago Bulls Flynn\\flynnma01",
+  "Player": "Malachi Flynn",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/flynnma01.jpg",
   "WS": "1",
-  "salary": "$7040880",
-  "projSalary": "$8920795",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "7040880.00",
+  "projSalary": "8920795.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ba"
+    "$oid": "62850368cd0631716c143c53"
   },
   "Rk": 171,
-  "Player": "Bryn Forbes\\forbebr01",
+  "Player": "Bryn Forbes",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/forbebr01.jpg",
   "WS": "1.4",
-  "salary": "$7009615",
+  "salary": "7009615.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8bb"
+    "$oid": "62850368cd0631716c143c54"
   },
   "Rk": 172,
-  "Player": "Aleem Ford\\forDallas Mavericks03",
+  "Player": "Aleem Ford",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/fordal03.jpg",
   "WS": "-0.2",
-  "salary": "$7622467",
-  "projSalary": "$333333",
+  "salary": "7622467.00",
+  "projSalary": "333333.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8bc"
+    "$oid": "62850368cd0631716c143c55"
   },
   "Rk": 173,
-  "Player": "Trent Forrest\\forretr01",
+  "Player": "Trent Forrest",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/forretr01.jpg",
   "WS": "1.3",
-  "salary": "$7000000",
-  "projSalary": "$7350000",
+  "salary": "7000000.00",
+  "projSalary": "7350000.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8bd"
+    "$oid": "62850368cd0631716c143c56"
   },
   "Rk": 174,
-  "Player": "Evan Fournier\\fournev01",
+  "Player": "Evan Fournier",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/fournev01.jpg",
   "WS": "3.7",
-  "salary": "$6984127",
-  "projSalary": "$7333333",
+  "salary": "6984127.00",
+  "projSalary": "7333333.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8be"
+    "$oid": "62850368cd0631716c143c57"
   },
   "Rk": 175,
-  "Player": "De'Aaron Fox\\foxde01",
+  "Player": "De'Aaron Fox",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/foxde01.jpg",
   "WS": "2.5",
-  "salary": "$6920027",
-  "projSalary": "$14150000",
+  "salary": "6920027.00",
+  "projSalary": "14150000.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8bf"
+    "$oid": "62850368cd0631716c143c58"
   },
   "Rk": 176,
-  "Player": "Melvin Frazier\\frazime01",
+  "Player": "Melvin Frazier",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/frazime01.jpg",
   "WS": "-0.4",
-  "salary": "$6720720",
-  "projSalary": "$7040880",
+  "salary": "6720720.00",
+  "projSalary": "7040880.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c0"
+    "$oid": "62850368cd0631716c143c59"
   },
   "Rk": 177,
-  "Player": "Tim Frazier\\fraziti01",
+  "Player": "Tim Frazier",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/fraziti01.jpg",
   "WS": "-0.2",
-  "salary": "$6593040",
-  "projSalary": "$6922440",
+  "salary": "6593040.00",
+  "projSalary": "6922440.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c1"
+    "$oid": "62850368cd0631716c143c5a"
   },
   "Rk": 178,
-  "Player": "Enes Freedom\\kanteen01",
+  "Player": "Enes Freedom",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kanteen01.jpg",
   "WS": "1.4",
-  "salary": "$6500000",
-  "projSalary": "$6000000",
+  "salary": "6500000.00",
+  "projSalary": "6000000.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c2"
+    "$oid": "62850368cd0631716c143c5b"
   },
   "Rk": 179,
-  "Player": "Markelle Fultz\\fultzma01",
+  "Player": "Markelle Fultz",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/fultzma01.jpg",
   "WS": "0.4",
-  "salary": "$6431666",
+  "salary": "6431666.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c3"
+    "$oid": "62850368cd0631716c143c5c"
   },
   "Rk": 180,
-  "Player": "Wenyen Gabriel\\gabriwe01",
+  "Player": "Wenyen Gabriel",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gabriwe01.jpg",
   "WS": "0.7",
-  "salary": "$6395160",
-  "projSalary": "$8109063",
+  "salary": "6395160.00",
+  "projSalary": "8109063.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c4"
+    "$oid": "62850368cd0631716c143c5d"
   },
   "Rk": 181,
-  "Player": "Daniel Gafford\\gaffoda01",
+  "Player": "Daniel Gafford",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gaffoda01.jpg",
   "WS": "6",
-  "salary": "$6350000",
-  "projSalary": "$6667750",
+  "salary": "6350000.00",
+  "projSalary": "6667750.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c5"
+    "$oid": "62850368cd0631716c143c5e"
   },
   "Rk": 182,
-  "Player": "Danilo Gallinari\\gallida01",
+  "Player": "Danilo Gallinari",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gallida01.jpg",
   "WS": "3.6",
-  "salary": "$6349671",
+  "salary": "6349671.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c6"
+    "$oid": "62850368cd0631716c143c5f"
   },
   "Rk": 183,
-  "Player": "Langston Galloway\\gallola01",
+  "Player": "Langston Galloway",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gallola01.jpg",
   "WS": "-0.2",
-  "salary": "$6175440",
-  "projSalary": "$6632880",
+  "salary": "6175440.00",
+  "projSalary": "6632880.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c7"
+    "$oid": "62850368cd0631716c143c60"
   },
   "Rk": 184,
-  "Player": "Darius Garland\\garlada01",
+  "Player": "Darius Garland",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/garlada01.jpg",
   "WS": "6.3",
-  "salary": "$6104280",
-  "projSalary": "$6395160",
+  "salary": "6104280.00",
+  "projSalary": "6395160.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c8"
+    "$oid": "62850368cd0631716c143c61"
   },
   "Rk": 185,
-  "Player": "Marcus Garrett\\garrema01",
+  "Player": "Marcus Garrett",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/garrema01.jpg",
   "WS": "0.1",
-  "salary": "$6006420",
-  "projSalary": "$6292440",
+  "salary": "6006420.00",
+  "projSalary": "6292440.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8c9"
+    "$oid": "62850368cd0631716c143c62"
   },
   "Rk": 186,
-  "Player": "Usman Garuba\\garubus01",
+  "Player": "Usman Garuba",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/garubus01.jpg",
   "WS": "0.5",
-  "salary": "$5988000",
-  "projSalary": "$6287400",
+  "salary": "5988000.00",
+  "projSalary": "6287400.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ca"
+    "$oid": "62850368cd0631716c143c63"
   },
   "Rk": 187,
-  "Player": "Luka Garza\\garzalu01",
+  "Player": "Luka Garza",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/garzalu01.jpg",
   "WS": "0.8",
-  "salary": "$5890000",
-  "projSalary": "$6184500",
+  "salary": "5890000.00",
+  "projSalary": "6184500.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8cb"
+    "$oid": "62850368cd0631716c143c64"
   },
   "Rk": 188,
-  "Player": "Rudy Gay\\gayru01",
+  "Player": "Rudy Gay",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gayru01.jpg",
   "WS": "2.1",
-  "salary": "$5890000",
+  "salary": "5890000.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8cc"
+    "$oid": "62850368cd0631716c143c65"
   },
   "Rk": 189,
-  "Player": "Paul George\\georgpa01",
+  "Player": "Paul George",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/georgpa01.jpg",
   "WS": "1.3",
-  "salary": "$5890000",
-  "projSalary": "$6184500",
+  "salary": "5890000.00",
+  "projSalary": "6184500.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8cd"
+    "$oid": "62850368cd0631716c143c66"
   },
   "Rk": 190,
-  "Player": "Taj Gibson\\gibsota01",
+  "Player": "Taj Gibson",
   "age": 36,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gibsota01.jpg",
   "WS": "2.7",
-  "salary": "$5845978",
+  "salary": "5845978.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ce"
+    "$oid": "62850368cd0631716c143c67"
   },
   "Rk": 191,
-  "Player": "Josh Giddey\\giddejo01",
+  "Player": "Josh Giddey",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/giddejo01.jpg",
   "WS": "0.4",
-  "salary": "$5837760",
-  "projSalary": "$7413955",
+  "salary": "5837760.00",
+  "projSalary": "7413955.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8cf"
+    "$oid": "62850368cd0631716c143c68"
   },
   "Rk": 192,
-  "Player": "Shai Gilgeous-Alexander\\gilgesh01",
+  "Player": "Shai Gilgeous-Alexander",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gilgesh01.jpg",
   "WS": "4.6",
-  "salary": "$5573334",
+  "salary": "5573334.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d0"
+    "$oid": "62850368cd0631716c143c69"
   },
   "Rk": 193,
-  "Player": "Anthony Gill\\gillan01",
+  "Player": "Anthony Gill",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gillan01.jpg",
   "WS": "1.4",
-  "salary": "$5572680",
-  "projSalary": "$5837760",
+  "salary": "5572680.00",
+  "projSalary": "5837760.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d1"
+    "$oid": "62850368cd0631716c143c6a"
   },
   "Rk": 194,
-  "Player": "Freddie Gillespie\\gillefr01",
+  "Player": "Freddie Gillespie",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gillefr01.jpg",
   "WS": "0.1",
-  "salary": "$5557725",
-  "projSalary": "$20089286",
+  "salary": "5557725.00",
+  "projSalary": "20089286.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d2"
+    "$oid": "62850368cd0631716c143c6b"
   },
   "Rk": 195,
-  "Player": "Rudy Gobert\\goberru01",
+  "Player": "Rudy Gobert",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/goberru01.jpg",
   "WS": "11.7",
-  "salary": "$5495532",
-  "projSalary": "$29750000",
+  "salary": "5495532.00",
+  "projSalary": "29750000.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d3"
+    "$oid": "62850368cd0631716c143c6c"
   },
   "Rk": 196,
-  "Player": "Brandon Goodwin\\goodwbr01",
+  "Player": "Brandon Goodwin",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/goodwbr01.jpg",
   "WS": "0.7",
-  "salary": "$5466360",
-  "projSalary": "$5739960",
+  "salary": "5466360.00",
+  "projSalary": "5739960.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d4"
+    "$oid": "62850368cd0631716c143c6d"
   },
   "Rk": 197,
-  "Player": "Jordan Goodwin\\goodwjo01",
+  "Player": "Jordan Goodwin",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/goodwjo01.jpg",
   "WS": "-0.1",
-  "salary": "$5421493",
+  "salary": "5421493.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d5"
+    "$oid": "62850368cd0631716c143c6e"
   },
   "Rk": 198,
-  "Player": "Aaron Gordon\\gordoaa01",
+  "Player": "Aaron Gordon",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gordoaa01.jpg",
   "WS": "5.2",
-  "salary": "$5348280",
-  "projSalary": "$6803012",
+  "salary": "5348280.00",
+  "projSalary": "6803012.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d6"
+    "$oid": "62850368cd0631716c143c6f"
   },
   "Rk": 199,
-  "Player": "Eric Gordon\\gordoer01",
+  "Player": "Eric Gordon",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/gordoer01.jpg",
   "WS": "1.4",
-  "salary": "$5333333",
-  "projSalary": "$5728395",
+  "salary": "5333333.00",
+  "projSalary": "5728395.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d7"
+    "$oid": "62850368cd0631716c143c70"
   },
   "Rk": 200,
-  "Player": "Devonte' Graham\\grahade01",
+  "Player": "Devonte' Graham",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/grahade01.jpg",
   "WS": "2.8",
-  "salary": "$5258735",
-  "projSalary": "$29750000",
-  "playerTeam": "NOP"
+  "salary": "5258735.00",
+  "projSalary": "29750000.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d8"
+    "$oid": "62850368cd0631716c143c71"
   },
   "Rk": 201,
-  "Player": "Jerami Grant\\grantje01",
+  "Player": "Jerami Grant",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/grantje01.jpg",
   "WS": "2.3",
-  "salary": "$5214584",
+  "salary": "5214584.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8d9"
+    "$oid": "62850368cd0631716c143c72"
   },
   "Rk": 202,
-  "Player": "Hassani Gravett\\graveha01",
+  "Player": "Hassani Gravett",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/graveha01.jpg",
   "WS": "0.3",
-  "salary": "$5200000",
-  "projSalary": "$5200000",
+  "salary": "5200000.00",
+  "projSalary": "5200000.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8da"
+    "$oid": "62850368cd0631716c143c73"
   },
   "Rk": 203,
-  "Player": "Danny Green\\greenda02",
+  "Player": "Danny Green",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/greenda02.jpg",
   "WS": "1.9",
-  "salary": "$5178572",
+  "salary": "5178572.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8db"
+    "$oid": "62850368cd0631716c143c74"
   },
   "Rk": 204,
-  "Player": "Draymond Green\\greendr01",
+  "Player": "Draymond Green",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/greendr01.jpg",
   "WS": "3.6",
-  "salary": "$5170564",
+  "salary": "5170564.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8dc"
+    "$oid": "62850368cd0631716c143c75"
   },
   "Rk": 205,
-  "Player": "Jalen Green\\greenja05",
+  "Player": "Jalen Green",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/greenja05.jpg",
   "WS": "0.7",
-  "salary": "$5105160",
-  "projSalary": "$5348280",
+  "salary": "5105160.00",
+  "projSalary": "5348280.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8dd"
+    "$oid": "62850368cd0631716c143c76"
   },
   "Rk": 206,
-  "Player": "JaMyCharlotte Hornetsl Green\\greenja01",
+  "Player": "JaMychal Green",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/greenja01.jpg",
   "WS": "2.7",
-  "salary": "$5007840",
-  "projSalary": "$5258280",
+  "salary": "5007840.00",
+  "projSalary": "5258280.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8de"
+    "$oid": "62850368cd0631716c143c77"
   },
   "Rk": 207,
-  "Player": "Javonte Green\\greenja02",
+  "Player": "Javonte Green",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/greenja02.jpg",
   "WS": "4.4",
-  "salary": "$5005350",
+  "salary": "5005350.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8df"
+    "$oid": "62850368cd0631716c143c78"
   },
   "Rk": 208,
-  "Player": "Jeff Green\\greenje02",
+  "Player": "Jeff Green",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/greenje02.jpg",
   "WS": "3.9",
-  "salary": "$5000000",
+  "salary": "5000000.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e0"
+    "$oid": "62850368cd0631716c143c79"
   },
   "Rk": 209,
-  "Player": "Josh Green\\greenjo02",
+  "Player": "Josh Green",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/greenjo02.jpg",
   "WS": "2.4",
-  "salary": "$5000000",
+  "salary": "5000000.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e1"
+    "$oid": "62850368cd0631716c143c7a"
   },
   "Rk": 210,
-  "Player": "Blake Griffin\\griffbl01",
+  "Player": "Blake Griffin",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/griffbl01.jpg",
   "WS": "2.1",
-  "salary": "$5000000",
-  "projSalary": "$5250000",
-  "playerTeam": "BRK"
+  "salary": "5000000.00",
+  "projSalary": "5250000.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e2"
+    "$oid": "62850368cd0631716c143c7b"
   },
   "Rk": 211,
-  "Player": "Quentin Grimes\\grimequ01",
+  "Player": "Quentin Grimes",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/grimequ01.jpg",
   "WS": "1.4",
-  "salary": "$5000000",
+  "salary": "5000000.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e3"
+    "$oid": "62850368cd0631716c143c7c"
   },
   "Rk": 212,
-  "Player": "Kyle Guy\\guyky01",
+  "Player": "Kyle Guy",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/guyky01.jpg",
   "WS": "0.1",
-  "salary": "$4990000",
+  "salary": "4990000.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e4"
+    "$oid": "62850368cd0631716c143c7d"
   },
   "Rk": 213,
-  "Player": "Rui HaChicago Bullsmura\\haChicago Bullsru01",
+  "Player": "Rui Hachimura",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hachiru01.jpg",
   "WS": "1.4",
-  "salary": "$4916160",
-  "projSalary": "$6263188",
+  "salary": "4916160.00",
+  "projSalary": "6263188.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e5"
+    "$oid": "62850368cd0631716c143c7e"
   },
   "Rk": 214,
-  "Player": "Tyrese Haliburton\\halibty01",
+  "Player": "Tyrese Haliburton",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/halibty01.jpg",
   "WS": "7",
-  "salary": "$4910000",
-  "projSalary": "$5155500",
+  "salary": "4910000.00",
+  "projSalary": "5155500.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e6"
+    "$oid": "62850368cd0631716c143c7f"
   },
   "Rk": 215,
-  "Player": "Tyler Hall\\hallty01",
+  "Player": "Tyler Hall",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hallty01.jpg",
   "WS": "0",
-  "salary": "$7310000",
-  "projSalary": "$5155000",
+  "salary": "7310000.00",
+  "projSalary": "5155000.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e7"
+    "$oid": "62850368cd0631716c143c80"
   },
   "Rk": 216,
-  "Player": "R.J. Hampton\\hamptrj01",
+  "Player": "R.J. Hampton",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hamptrj01.jpg",
   "WS": "-0.2",
-  "salary": "$4910000",
-  "projSalary": "$5155500",
+  "salary": "4910000.00",
+  "projSalary": "5155500.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e8"
+    "$oid": "62850368cd0631716c143c81"
   },
   "Rk": 217,
-  "Player": "Tim Hardaway Jr.\\hardati02",
+  "Player": "Tim Hardaway Jr.",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hardati02.jpg",
   "WS": "2",
-  "salary": "$4878049",
-  "projSalary": "$5121951",
+  "salary": "4878049.00",
+  "projSalary": "5121951.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8e9"
+    "$oid": "62850368cd0631716c143c82"
   },
   "Rk": 218,
-  "Player": "James HarDenver Nuggets\\hardeja01",
+  "Player": "James Harden",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hardeja01.jpg",
   "WS": "7.6",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ea"
+    "$oid": "62850368cd0631716c143c83"
   },
   "Rk": 219,
-  "Player": "Maurice Harkless\\harklma01",
+  "Player": "Maurice Harkless",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/harklma01.jpg",
   "WS": "0.5",
-  "salary": "$4736102",
+  "salary": "4736102.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8eb"
+    "$oid": "62850368cd0631716c143c84"
   },
   "Rk": 220,
-  "Player": "Jared Harper\\harpeja01",
+  "Player": "Jared Harper",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/harpeja01.jpg",
   "WS": "0.4",
-  "salary": "$4692840",
-  "projSalary": "$4916160",
-  "playerTeam": "NOP"
+  "salary": "4692840.00",
+  "projSalary": "4916160.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ec"
+    "$oid": "62850368cd0631716c143c85"
   },
   "Rk": 221,
-  "Player": "Montrezl Harrell\\harremo01",
+  "Player": "Montrezl Harrell",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/harremo01.jpg",
   "WS": "7.3",
-  "salary": "$4675830",
+  "salary": "4675830.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ed"
+    "$oid": "62850368cd0631716c143c86"
   },
   "Rk": 222,
-  "Player": "Gary Harris\\harriga01",
+  "Player": "Gary Harris",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/harriga01.jpg",
   "WS": "2.2",
-  "salary": "$4670160",
-  "projSalary": "$5954454",
+  "salary": "4670160.00",
+  "projSalary": "5954454.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ee"
+    "$oid": "62850368cd0631716c143c87"
   },
   "Rk": 223,
-  "Player": "Joe Harris\\harrijo01",
+  "Player": "Joe Harris",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/harrijo01.jpg",
   "WS": "0.5",
-  "salary": "$4650000",
-  "projSalary": "$5022000",
-  "playerTeam": "BRK"
+  "salary": "4650000.00",
+  "projSalary": "5022000.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ef"
+    "$oid": "62850368cd0631716c143c88"
   },
   "Rk": 224,
-  "Player": "Tobias Harris\\harrito02",
+  "Player": "Tobias Harris",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/harrito02.jpg",
   "WS": "5.6",
-  "salary": "$4629630",
-  "projSalary": "$5000000",
+  "salary": "4629630.00",
+  "projSalary": "5000000.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f0"
+    "$oid": "62850368cd0631716c143c89"
   },
   "Rk": 225,
-  "Player": "Shaquille Harrison\\harrish01",
+  "Player": "Shaquille Harrison",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/harrish01.jpg",
   "WS": "0",
-  "salary": "$4603320",
-  "projSalary": "$4833600",
-  "playerTeam": "BRK"
+  "salary": "4603320.00",
+  "projSalary": "4833600.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f1"
+    "$oid": "62850368cd0631716c143c8a"
   },
   "Rk": 226,
-  "Player": "Josh Hart\\hartjo01",
+  "Player": "Josh Hart",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hartjo01.jpg",
   "WS": "4.4",
-  "salary": "$4500000",
-  "projSalary": "$4725000",
+  "salary": "4500000.00",
+  "projSalary": "4725000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f2"
+    "$oid": "62850368cd0631716c143c8b"
   },
   "Rk": 227,
-  "Player": "Isaiah Hartenstein\\harteis01",
+  "Player": "Isaiah Hartenstein",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/harteis01.jpg",
   "WS": "5.5",
-  "salary": "$4500000",
-  "projSalary": "$4500000",
+  "salary": "4500000.00",
+  "projSalary": "4500000.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f3"
+    "$oid": "62850368cd0631716c143c8c"
   },
   "Rk": 228,
-  "Player": "Udonis Haslem\\hasleud01",
+  "Player": "Udonis Haslem",
   "age": 41,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hasleud01.jpg",
   "WS": "0.1",
-  "salary": "$4458000",
-  "projSalary": "$4670160",
+  "salary": "4458000.00",
+  "projSalary": "4670160.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f4"
+    "$oid": "62850368cd0631716c143c8d"
   },
   "Rk": 229,
-  "Player": "Sam Hauser\\hausesa01",
+  "Player": "Sam Hauser",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hausesa01.jpg",
   "WS": "0.6",
-  "salary": "$4447896",
+  "salary": "4447896.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f5"
+    "$oid": "62850368cd0631716c143c8e"
   },
   "Rk": 230,
-  "Player": "Jaxson Hayes\\hayesja02",
+  "Player": "Jaxson Hayes",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hayesja02.jpg",
   "WS": "5.1",
-  "salary": "$4437000",
-  "projSalary": "$5887899",
-  "playerTeam": "NOP"
+  "salary": "4437000.00",
+  "projSalary": "5887899.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f6"
+    "$oid": "62850368cd0631716c143c8f"
   },
   "Rk": 231,
-  "Player": "Killian Hayes\\hayeski01",
+  "Player": "Killian Hayes",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hayeski01.jpg",
   "WS": "0.5",
-  "salary": "$4373160",
-  "projSalary": "$4591920",
+  "salary": "4373160.00",
+  "projSalary": "4591920.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f7"
+    "$oid": "62850368cd0631716c143c90"
   },
   "Rk": 232,
-  "Player": "Gordon Hayward\\haywago01",
+  "Player": "Gordon Hayward",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/haywago01.jpg",
   "WS": "2.8",
-  "salary": "$4347600",
-  "projSalary": "$4564980",
-  "playerTeam": "CHO"
+  "salary": "4347600.00",
+  "projSalary": "4564980.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f8"
+    "$oid": "62850368cd0631716c143c91"
   },
   "Rk": 233,
-  "Player": "Aaron Henry\\henryaa01",
+  "Player": "Aaron Henry",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/henryaa01.jpg",
   "WS": "-0.1",
-  "salary": "$4347600",
-  "projSalary": "$4564980",
+  "salary": "4347600.00",
+  "projSalary": "4564980.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8f9"
+    "$oid": "62850368cd0631716c143c92"
   },
   "Rk": 234,
-  "Player": "Juancho Hernangómez\\hernaju01",
+  "Player": "Juancho Hernangómez",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hernaju01.jpg",
   "WS": "0.9",
-  "salary": "$4259259",
-  "projSalary": "$4600000",
+  "salary": "4259259.00",
+  "projSalary": "4600000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8fa"
+    "$oid": "62850368cd0631716c143c93"
   },
   "Rk": 235,
-  "Player": "Willy Hernangómez\\hernawi01",
+  "Player": "Willy Hernangómez",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hernawi01.jpg",
   "WS": "3.2",
-  "salary": "$4253357",
-  "projSalary": "$14508929",
-  "playerTeam": "NOP"
+  "salary": "4253357.00",
+  "projSalary": "14508929.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8fb"
+    "$oid": "62850368cd0631716c143c94"
   },
   "Rk": 236,
-  "Player": "Tyler Herro\\herroty01",
+  "Player": "Tyler Herro",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/herroty01.jpg",
   "WS": "3.8",
-  "salary": "$4235160",
-  "projSalary": "$4437000",
+  "salary": "4235160.00",
+  "projSalary": "4437000.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8fc"
+    "$oid": "62850368cd0631716c143c95"
   },
   "Rk": 237,
-  "Player": "Buddy Hield\\hieldbu01",
+  "Player": "Buddy Hield",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hieldbu01.jpg",
   "WS": "1.9",
-  "salary": "$4215120",
-  "projSalary": "$5808435",
+  "salary": "4215120.00",
+  "projSalary": "5808435.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8fd"
+    "$oid": "62850368cd0631716c143c96"
   },
   "Rk": 238,
-  "Player": "Haywood Highsmith\\highsha01",
+  "Player": "Haywood Highsmith",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/highsha01.jpg",
   "WS": "0.1",
-  "salary": "$4154400",
-  "projSalary": "$4362240",
+  "salary": "4154400.00",
+  "projSalary": "4362240.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8fe"
+    "$oid": "62850368cd0631716c143c97"
   },
   "Rk": 239,
-  "Player": "George Hill\\hillge01",
+  "Player": "George Hill",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hillge01.jpg",
   "WS": "2.3",
-  "salary": "$4087904",
+  "salary": "4087904.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d8ff"
+    "$oid": "62850368cd0631716c143c98"
   },
   "Rk": 240,
-  "Player": "Malcolm Hill\\hillma01",
+  "Player": "Malcolm Hill",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hillma01.jpg",
   "WS": "0.6",
-  "salary": "$4054695",
-  "projSalary": "$9615385",
+  "salary": "4054695.00",
+  "projSalary": "9615385.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d900"
+    "$oid": "62850368cd0631716c143c99"
   },
   "Rk": 241,
-  "Player": "Solomon Hill\\hillso01",
+  "Player": "Solomon Hill",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hillso01.jpg",
   "WS": "0",
-  "salary": "$4023600",
-  "projSalary": "$4215120",
+  "salary": "4023600.00",
+  "projSalary": "4215120.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d901"
+    "$oid": "62850368cd0631716c143c9a"
   },
   "Rk": 242,
-  "Player": "Nate Hinton\\hintona01",
+  "Player": "Nate Hinton",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hintona01.jpg",
   "WS": "-0.1",
-  "salary": "$4004280",
-  "projSalary": "$5722116",
+  "salary": "4004280.00",
+  "projSalary": "5722116.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d902"
+    "$oid": "62850368cd0631716c143c9b"
   },
   "Rk": 243,
-  "Player": "Jaylen Hoard\\hoardja01",
+  "Player": "Jaylen Hoard",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hoardja01.jpg",
   "WS": "0.6",
-  "salary": "$4000000",
-  "projSalary": "$12402000",
+  "salary": "4000000.00",
+  "projSalary": "12402000.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d903"
+    "$oid": "62850368cd0631716c143c9c"
   },
   "Rk": 244,
-  "Player": "Aaron Holiday\\holidaa01",
+  "Player": "Aaron Holiday",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/holidaa01.jpg",
   "WS": "1.5",
-  "salary": "$4000000",
-  "projSalary": "$4000000",
+  "salary": "4000000.00",
+  "projSalary": "4000000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d904"
+    "$oid": "62850368cd0631716c143c9d"
   },
   "Rk": 245,
-  "Player": "Jrue Holiday\\holidjr01",
+  "Player": "Jrue Holiday",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/holidjr01.jpg",
   "WS": "6.9",
-  "salary": "$4000000",
-  "projSalary": "$4000000",
+  "salary": "4000000.00",
+  "projSalary": "4000000.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d905"
+    "$oid": "62850368cd0631716c143c9e"
   },
   "Rk": 246,
-  "Player": "Justin Holiday\\holidju01",
+  "Player": "Justin Holiday",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/holidju01.jpg",
   "WS": "1.4",
-  "salary": "$4000000",
+  "salary": "4000000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d906"
+    "$oid": "62850368cd0631716c143c9f"
   },
   "Rk": 247,
-  "Player": "RiCharlotte Hornetsun Holmes\\holmeri01",
+  "Player": "Richaun Holmes",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/holmeri01.jpg",
   "WS": "3.2",
-  "salary": "$3980551",
+  "salary": "3980551.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d907"
+    "$oid": "62850368cd0631716c143ca0"
   },
   "Rk": 248,
-  "Player": "Rodney Hood\\hoodro01",
+  "Player": "Rodney Hood",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hoodro01.jpg",
   "WS": "0.7",
-  "salary": "$3946800",
-  "projSalary": "$4144320",
+  "salary": "3946800.00",
+  "projSalary": "4144320.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d908"
+    "$oid": "62850368cd0631716c143ca1"
   },
   "Rk": 249,
-  "Player": "Scotty Hopson\\hopsosc01",
+  "Player": "Scotty Hopson",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hopsosc01.jpg",
   "WS": "0",
-  "salary": "$3940184",
+  "salary": "3940184.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d909"
+    "$oid": "62850368cd0631716c143ca2"
   },
   "Rk": 250,
-  "Player": "Al Horford\\horfoal01",
+  "Player": "Al Horford",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/horfoal01.jpg",
   "WS": "7.6",
-  "salary": "$3938818",
+  "salary": "3938818.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d90a"
+    "$oid": "62850368cd0631716c143ca3"
   },
   "Rk": 251,
-  "Player": "Talen Horton-Tucker\\hortota01",
+  "Player": "Talen Horton-Tucker",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hortota01.jpg",
   "WS": "1.1",
-  "salary": "$3902439",
-  "projSalary": "$4097561",
+  "salary": "3902439.00",
+  "projSalary": "4097561.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d90b"
+    "$oid": "62850368cd0631716c143ca4"
   },
   "Rk": 252,
-  "Player": "Danuel Houston Rocketsse Jr.\\Houston Rocketsseda01",
+  "Player": "Danuel House Jr.",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/houseda01.jpg",
   "WS": "1",
-  "salary": "$3822240",
-  "projSalary": "$4004280",
+  "salary": "3822240.00",
+  "projSalary": "4004280.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d90c"
+    "$oid": "62850368cd0631716c143ca5"
   },
   "Rk": 253,
-  "Player": "Dwight Howard\\howardw01",
+  "Player": "Dwight Howard",
   "age": 36,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/howardw01.jpg",
   "WS": "3.5",
-  "salary": "$3804360",
-  "projSalary": "$5634257",
+  "salary": "3804360.00",
+  "projSalary": "5634257.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d90d"
+    "$oid": "62850368cd0631716c143ca6"
   },
   "Rk": 254,
-  "Player": "Markus Howard\\howarma02",
+  "Player": "Markus Howard",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/howarma02.jpg",
   "WS": "0.3",
-  "salary": "$3804150",
+  "salary": "3804150.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d90e"
+    "$oid": "62850368cd0631716c143ca7"
   },
   "Rk": 255,
-  "Player": "Kevin Huerter\\huertke01",
+  "Player": "Kevin Huerter",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/huertke01.jpg",
   "WS": "2.8",
-  "salary": "$3768342",
-  "projSalary": "$9598214",
+  "salary": "3768342.00",
+  "projSalary": "9598214.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d90f"
+    "$oid": "62850368cd0631716c143ca8"
   },
   "Rk": 256,
-  "Player": "Jay Huff\\huffja01",
+  "Player": "Jay Huff",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/huffja01.jpg",
   "WS": "0",
-  "salary": "$3749520",
-  "projSalary": "$3936960",
+  "salary": "3749520.00",
+  "projSalary": "3936960.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d910"
+    "$oid": "62850368cd0631716c143ca9"
   },
   "Rk": 257,
-  "Player": "Elijah Hughes\\hugheel01",
+  "Player": "Elijah Hughes",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hugheel01.jpg",
   "WS": "-0.4",
-  "salary": "$3731707",
-  "projSalary": "$3918293",
+  "salary": "3731707.00",
+  "projSalary": "3918293.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d911"
+    "$oid": "62850368cd0631716c143caa"
   },
   "Rk": 258,
-  "Player": "Feron Hunt\\huntfe01",
+  "Player": "Feron Hunt",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/huntfe01.jpg",
   "WS": "0",
-  "salary": "$3661976",
-  "projSalary": "$10700000",
+  "salary": "3661976.00",
+  "projSalary": "10700000.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d912"
+    "$oid": "62850368cd0631716c143cab"
   },
   "Rk": 259,
-  "Player": "De'Andre Hunter\\huntede01",
+  "Player": "De'Andre Hunter",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/huntede01.jpg",
   "WS": "1.1",
-  "salary": "$4107149",
-  "projSalary": "$3925000",
+  "salary": "4107149.00",
+  "projSalary": "3925000.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d913"
+    "$oid": "62850368cd0631716c143cac"
   },
   "Rk": 260,
-  "Player": "Charlotte Hornetsndler HutChicago Bullsson\\hutchch01",
+  "Player": "Chandler Hutchison",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hutchch01.jpg",
   "WS": "0",
-  "salary": "$3631200",
-  "projSalary": "$3804360",
+  "salary": "3631200.00",
+  "projSalary": "3804360.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d914"
+    "$oid": "62850368cd0631716c143cad"
   },
   "Rk": 261,
-  "Player": "Bones Hyland\\hylanbo01",
+  "Player": "Bones Hyland",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/hylanbo01.jpg",
   "WS": "2.4",
-  "salary": "$3562080",
-  "projSalary": "$3740160",
+  "salary": "3562080.00",
+  "projSalary": "3740160.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d915"
+    "$oid": "62850368cd0631716c143cae"
   },
   "Rk": 262,
-  "Player": "Serge Ibaka\\ibakase01",
+  "Player": "Serge Ibaka",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ibakase01.jpg",
   "WS": "2",
-  "salary": "$3500000",
-  "projSalary": "$3500000",
+  "salary": "3500000.00",
+  "projSalary": "3500000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d916"
+    "$oid": "62850368cd0631716c143caf"
   },
   "Rk": 263,
-  "Player": "Andre IguoDallas Mavericksa\\iguodan01",
+  "Player": "Andre Iguodala",
   "age": 38,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/iguodan01.jpg",
   "WS": "1.6",
-  "salary": "$3500000",
-  "projSalary": "$3500000",
+  "salary": "3500000.00",
+  "projSalary": "3500000.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d917"
+    "$oid": "62850368cd0631716c143cb0"
   },
   "Rk": 264,
-  "Player": "Joe Ingles\\inglejo01",
+  "Player": "Joe Ingles",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/inglejo01.jpg",
   "WS": "2.2",
-  "salary": "$3449400",
-  "projSalary": "$3613680",
+  "salary": "3449400.00",
+  "projSalary": "3613680.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d918"
+    "$oid": "62850368cd0631716c143cb1"
   },
   "Rk": 265,
-  "Player": "Brandon Ingram\\ingrabr01",
+  "Player": "Brandon Ingram",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ingrabr01.jpg",
   "WS": "3.9",
-  "salary": "$3383640",
-  "projSalary": "$3552960",
-  "playerTeam": "NOP"
+  "salary": "3383640.00",
+  "projSalary": "3552960.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d919"
+    "$oid": "62850368cd0631716c143cb2"
   },
   "Rk": 266,
-  "Player": "Kyrie Irving\\irvinky01",
+  "Player": "Kyrie Irving",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/irvinky01.jpg",
   "WS": "3.3",
-  "salary": "$3333333",
-  "projSalary": "$3492063",
-  "playerTeam": "BRK"
+  "salary": "3333333.00",
+  "projSalary": "3492063.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d91a"
+    "$oid": "62850368cd0631716c143cb3"
   },
   "Rk": 267,
-  "Player": "Wes Iwundu\\iwundwe01",
+  "Player": "Wes Iwundu",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/iwundwe01.jpg",
   "WS": "0.1",
-  "salary": "$3300000",
-  "projSalary": "$3465000",
+  "salary": "3300000.00",
+  "projSalary": "3465000.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d91b"
+    "$oid": "62850368cd0631716c143cb4"
   },
   "Rk": 268,
-  "Player": "Frank Jackson\\jacksfr01",
+  "Player": "Frank Jackson",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jacksfr01.jpg",
   "WS": "0.7",
-  "salary": "$3277080",
-  "projSalary": "$3433320",
+  "salary": "3277080.00",
+  "projSalary": "3433320.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d91c"
+    "$oid": "62850368cd0631716c143cb5"
   },
   "Rk": 269,
-  "Player": "Isaiah Jackson\\jacksis01",
+  "Player": "Isaiah Jackson",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jacksis01.jpg",
   "WS": "1.4",
-  "salary": "$3277080",
-  "projSalary": "$3433320",
+  "salary": "3277080.00",
+  "projSalary": "3433320.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d91d"
+    "$oid": "62850368cd0631716c143cb6"
   },
   "Rk": 270,
-  "Player": "Jaren Jackson Jr.\\jacksja02",
+  "Player": "Jaren Jackson Jr.",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jacksja02.jpg",
   "WS": "5.4",
-  "salary": "$3261480",
-  "projSalary": "$5009633",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "3261480.00",
+  "projSalary": "5009633.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d91e"
+    "$oid": "62850368cd0631716c143cb7"
   },
   "Rk": 271,
-  "Player": "Josh Jackson\\jacksjo02",
+  "Player": "Josh Jackson",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jacksjo02.jpg",
   "WS": "0",
-  "salary": "$3214680",
-  "projSalary": "$3375480",
+  "salary": "3214680.00",
+  "projSalary": "3375480.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d91f"
+    "$oid": "62850368cd0631716c143cb8"
   },
   "Rk": 272,
-  "Player": "Justin Jackson\\jacksju01",
+  "Player": "Justin Jackson",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jacksju01.jpg",
   "WS": "0",
-  "salary": "$12213507",
-  "projSalary": "$12372008",
+  "salary": "12213507.00",
+  "projSalary": "12372008.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d920"
+    "$oid": "62850368cd0631716c143cb9"
   },
   "Rk": 273,
-  "Player": "Reggie Jackson\\jacksre01",
+  "Player": "Reggie Jackson",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jacksre01.jpg",
   "WS": "0.4",
-  "salary": "$3169347",
+  "salary": "3169347.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d921"
+    "$oid": "62850368cd0631716c143cba"
   },
   "Rk": 274,
-  "Player": "LeBron James\\jamesle01",
+  "Player": "LeBron James",
   "age": 37,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jamesle01.jpg",
   "WS": "7.5",
-  "salary": "$3113160",
-  "projSalary": "$3261480",
+  "salary": "3113160.00",
+  "projSalary": "3261480.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d922"
+    "$oid": "62850368cd0631716c143cbb"
   },
   "Rk": 275,
-  "Player": "DeJon Jarreau\\jarrede01",
+  "Player": "DeJon Jarreau",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jarrede01.jpg",
   "WS": "0",
-  "salary": "$3098400",
-  "projSalary": "$4765339",
+  "salary": "3098400.00",
+  "projSalary": "4765339.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d923"
+    "$oid": "62850368cd0631716c143cbc"
   },
   "Rk": 276,
-  "Player": "DaQuan Jeffries\\jeffrda01",
+  "Player": "DaQuan Jeffries",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jeffrda01.jpg",
   "WS": "0",
-  "salary": "$3053760",
-  "projSalary": "$3206640",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "3053760.00",
+  "projSalary": "3206640.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d924"
+    "$oid": "62850368cd0631716c143cbd"
   },
   "Rk": 277,
-  "Player": "Ty Jerome\\jeromty01",
+  "Player": "Ty Jerome",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jeromty01.jpg",
   "WS": "0.5",
-  "salary": "$3000000",
-  "projSalary": "$3000000",
+  "salary": "3000000.00",
+  "projSalary": "3000000.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d925"
+    "$oid": "62850368cd0631716c143cbe"
   },
   "Rk": 278,
-  "Player": "Isaiah Joe\\joeis01",
+  "Player": "Isaiah Joe",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/joeis01.jpg",
   "WS": "0.4",
-  "salary": "$3000000",
+  "salary": "3000000.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d926"
+    "$oid": "62850368cd0631716c143cbf"
   },
   "Rk": 279,
-  "Player": "Alize Johnson\\johnsal02",
+  "Player": "Alize Johnson",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsal02.jpg",
   "WS": "0.1",
-  "salary": "$3000000",
-  "projSalary": "$3150000",
+  "salary": "3000000.00",
+  "projSalary": "3150000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d927"
+    "$oid": "62850368cd0631716c143cc0"
   },
   "Rk": 280,
-  "Player": "B.J. Johnson\\johnsbj01",
+  "Player": "B.J. Johnson",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsbj01.jpg",
   "WS": "0.1",
-  "salary": "$2957520",
-  "projSalary": "$3098400",
+  "salary": "2957520.00",
+  "projSalary": "3098400.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d928"
+    "$oid": "62850368cd0631716c143cc1"
   },
   "Rk": 281,
-  "Player": "Cameron Johnson\\johnsca02",
+  "Player": "Cameron Johnson",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsca02.jpg",
   "WS": "5.6",
-  "salary": "$2901240",
-  "projSalary": "$3046200",
+  "salary": "2901240.00",
+  "projSalary": "3046200.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d929"
+    "$oid": "62850368cd0631716c143cc2"
   },
   "Rk": 282,
-  "Player": "David Johnson\\johnsda08",
+  "Player": "David Johnson",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsda08.jpg",
   "WS": "0",
-  "salary": "$5256308",
-  "projSalary": "$2866667",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "5256308.00",
+  "projSalary": "2866667.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d92a"
+    "$oid": "62850368cd0631716c143cc3"
   },
   "Rk": 283,
-  "Player": "Jalen Johnson\\johnsja05",
+  "Player": "Jalen Johnson",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsja05.jpg",
   "WS": "0",
-  "salary": "$2844429",
-  "projSalary": "$2844429",
+  "salary": "2844429.00",
+  "projSalary": "2844429.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d92b"
+    "$oid": "62850368cd0631716c143cc4"
   },
   "Rk": 284,
-  "Player": "James Johnson\\johnsja01",
+  "Player": "James Johnson",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsja01.jpg",
   "WS": "1.7",
-  "salary": "$2840160",
-  "projSalary": "$4379527",
-  "playerTeam": "BRK"
+  "salary": "2840160.00",
+  "projSalary": "4379527.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d92c"
+    "$oid": "62850368cd0631716c143cc5"
   },
   "Rk": 285,
-  "Player": "Joe Johnson\\johnsjo02",
+  "Player": "Joe Johnson",
   "age": 40,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsjo02.jpg",
   "WS": "0",
-  "salary": "$2824320",
-  "projSalary": "$2959080",
+  "salary": "2824320.00",
+  "projSalary": "2959080.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d92d"
+    "$oid": "62850368cd0631716c143cc6"
   },
   "Rk": 286,
-  "Player": "Keldon Johnson\\johnske04",
+  "Player": "Keldon Johnson",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnske04.jpg",
   "WS": "4.9",
-  "salary": "$2770560",
-  "projSalary": "$2909160",
+  "salary": "2770560.00",
+  "projSalary": "2909160.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d92e"
+    "$oid": "62850368cd0631716c143cc7"
   },
   "Rk": 287,
-  "Player": "Keon Johnson\\johnske07",
+  "Player": "Keon Johnson",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnske07.jpg",
   "WS": "-0.5",
-  "salary": "$2726880",
-  "projSalary": "$4343920",
+  "salary": "2726880.00",
+  "projSalary": "4343920.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d92f"
+    "$oid": "62850368cd0631716c143cc8"
   },
   "Rk": 288,
-  "Player": "Stanley Johnson\\johnsst04",
+  "Player": "Stanley Johnson",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsst04.jpg",
   "WS": "1.8",
-  "salary": "$2711280",
-  "projSalary": "$2840160",
+  "salary": "2711280.00",
+  "projSalary": "2840160.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d930"
+    "$oid": "62850368cd0631716c143cc9"
   },
   "Rk": 289,
-  "Player": "Tyler Johnson\\johnsty01",
+  "Player": "Tyler Johnson",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/johnsty01.jpg",
   "WS": "0.1",
-  "salary": "$2659560",
-  "projSalary": "$2792520",
+  "salary": "2659560.00",
+  "projSalary": "2792520.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d931"
+    "$oid": "62850368cd0631716c143cca"
   },
   "Rk": 290,
-  "Player": "Nikola Jokić\\jokicni01",
+  "Player": "Nikola Jokić",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jokicni01.jpg",
   "WS": "15.2",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d932"
+    "$oid": "62850368cd0631716c143ccb"
   },
   "Rk": 291,
-  "Player": "Carlik Jones\\jonesca03",
+  "Player": "Carlik Jones",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jonesca03.jpg",
   "WS": "-0.1",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d933"
+    "$oid": "62850368cd0631716c143ccc"
   },
   "Rk": 292,
-  "Player": "DaMiami Heatn Jones\\jonesda03",
+  "Player": "Damian Jones",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jonesda03.jpg",
   "WS": "3.3",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d934"
+    "$oid": "62850368cd0631716c143ccd"
   },
   "Rk": 293,
-  "Player": "Derrick Jones Jr.\\jonesde02",
+  "Player": "Derrick Jones Jr.",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jonesde02.jpg",
   "WS": "2.2",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d935"
+    "$oid": "62850368cd0631716c143cce"
   },
   "Rk": 294,
-  "Player": "Herbert Jones\\joneshe01",
+  "Player": "Herbert Jones",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/joneshe01.jpg",
   "WS": "4.6",
-  "salary": "$2641691",
-  "playerTeam": "NOP"
+  "salary": "2641691.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d936"
+    "$oid": "62850368cd0631716c143ccf"
   },
   "Rk": 295,
-  "Player": "Jemerrio Jones\\jonesje01",
+  "Player": "Jemerrio Jones",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jonesje01.jpg",
   "WS": "0.1",
-  "salary": "$11109327",
-  "projSalary": "$7827907",
+  "salary": "11109327.00",
+  "projSalary": "7827907.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d937"
+    "$oid": "62850368cd0631716c143cd0"
   },
   "Rk": 296,
-  "Player": "Kai Jones\\joneska01",
+  "Player": "Kai Jones",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/joneska01.jpg",
   "WS": "0",
-  "salary": "$2641691",
-  "playerTeam": "CHO"
+  "salary": "2641691.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d938"
+    "$oid": "62850368cd0631716c143cd1"
   },
   "Rk": 297,
-  "Player": "Mason Jones\\jonesma05",
+  "Player": "Mason Jones",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jonesma05.jpg",
   "WS": "0.2",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d939"
+    "$oid": "62850368cd0631716c143cd2"
   },
   "Rk": 298,
-  "Player": "Tre Jones\\jonestr01",
+  "Player": "Tre Jones",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jonestr01.jpg",
   "WS": "2.9",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d93a"
+    "$oid": "62850368cd0631716c143cd3"
   },
   "Rk": 299,
-  "Player": "Tyus Jones\\jonesty01",
+  "Player": "Tyus Jones",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jonesty01.jpg",
   "WS": "5.1",
-  "salary": "$2641691",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "2641691.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d93b"
+    "$oid": "62850368cd0631716c143cd4"
   },
   "Rk": 300,
-  "Player": "DeAndre Jordan\\jordade01",
+  "Player": "DeAndre Jordan",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/jordade01.jpg",
   "WS": "1.9",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d93c"
+    "$oid": "62850368cd0631716c143cd5"
   },
   "Rk": 301,
-  "Player": "Cory Joseph\\josepco01",
+  "Player": "Cory Joseph",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/josepco01.jpg",
   "WS": "2.5",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d93d"
+    "$oid": "62850368cd0631716c143cd6"
   },
   "Rk": 302,
-  "Player": "Georgios Kalaitzakis\\kalaige01",
+  "Player": "Georgios Kalaitzakis",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kalaige01.jpg",
   "WS": "-0.1",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d93e"
+    "$oid": "62850368cd0631716c143cd7"
   },
   "Rk": 303,
-  "Player": "Frank KaMinnesota Timberwolvessky\\kaMinnesota Timberwolvesfr01",
+  "Player": "Frank Kaminsky",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kaminfr01.jpg",
   "WS": "0.9",
-  "salary": "$32405817",
+  "salary": "32405817.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d93f"
+    "$oid": "62850368cd0631716c143cd8"
   },
   "Rk": 304,
-  "Player": "Luke Kennard\\kennalu01",
+  "Player": "Luke Kennard",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kennalu01.jpg",
   "WS": "4.5",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d940"
+    "$oid": "62850368cd0631716c143cd9"
   },
   "Rk": 305,
-  "Player": "Braxton Key\\keybr01",
+  "Player": "Braxton Key",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/keybr01.jpg",
   "WS": "0.2",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d941"
+    "$oid": "62850368cd0631716c143cda"
   },
   "Rk": 306,
-  "Player": "George King\\kingge03",
+  "Player": "George King",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kingge03.jpg",
   "WS": "-0.1",
-  "salary": "$2641691",
+  "salary": "2641691.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d942"
+    "$oid": "62850368cd0631716c143cdb"
   },
   "Rk": 307,
-  "Player": "Louis King\\kinglo02",
+  "Player": "Louis King",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kinglo02.jpg",
   "WS": "0",
-  "salary": "$2617800",
-  "projSalary": "$4306281",
+  "salary": "2617800.00",
+  "projSalary": "4306281.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d943"
+    "$oid": "62850368cd0631716c143cdc"
   },
   "Rk": 308,
-  "Player": "Corey Kispert\\kispeco01",
+  "Player": "Corey Kispert",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kispeco01.jpg",
   "WS": "2.3",
-  "salary": "$2602920",
-  "projSalary": "$2726880",
+  "salary": "2602920.00",
+  "projSalary": "2726880.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d944"
+    "$oid": "62850368cd0631716c143cdd"
   },
   "Rk": 309,
-  "Player": "Maxi Kleber\\klebima01",
+  "Player": "Maxi Kleber",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/klebima01.jpg",
   "WS": "3",
-  "salary": "$2553120",
-  "projSalary": "$2681040",
+  "salary": "2553120.00",
+  "projSalary": "2681040.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d945"
+    "$oid": "62850368cd0631716c143cde"
   },
   "Rk": 310,
-  "Player": "Brandon Knight\\knighbr03",
+  "Player": "Brandon Knight",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/knighbr03.jpg",
   "WS": "0.1",
-  "salary": "$2513040",
-  "projSalary": "$4264629",
+  "salary": "2513040.00",
+  "projSalary": "4264629.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d946"
+    "$oid": "62850368cd0631716c143cdf"
   },
   "Rk": 311,
-  "Player": "Nathan Knight\\knighna01",
+  "Player": "Nathan Knight",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/knighna01.jpg",
   "WS": "1",
-  "salary": "$2500000",
-  "projSalary": "$2625000",
+  "salary": "2500000.00",
+  "projSalary": "2625000.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d947"
+    "$oid": "62850368cd0631716c143ce0"
   },
   "Rk": 312,
-  "Player": "Kevin Knox\\knoxke01",
+  "Player": "Kevin Knox",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/knoxke01.jpg",
   "WS": "0.2",
-  "salary": "$2498760",
-  "projSalary": "$2617800",
+  "salary": "2498760.00",
+  "projSalary": "2617800.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d948"
+    "$oid": "62850368cd0631716c143ce1"
   },
   "Rk": 313,
-  "Player": "John KonCharlotte Hornetsr\\konchjo01",
+  "Player": "John Konchar",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/konchjo01.jpg",
   "WS": "4.2",
-  "salary": "$2451120",
-  "projSalary": "$2573760",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "2451120.00",
+  "projSalary": "2573760.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d949"
+    "$oid": "62850368cd0631716c143ce2"
   },
   "Rk": 314,
-  "Player": "Furkan Korkmaz\\korkmfu01",
+  "Player": "Furkan Korkmaz",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/korkmfu01.jpg",
   "WS": "1.2",
-  "salary": "$2412840",
-  "projSalary": "$4220057",
+  "salary": "2412840.00",
+  "projSalary": "4220057.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d94a"
+    "$oid": "62850368cd0631716c143ce3"
   },
   "Rk": 315,
-  "Player": "Luke Kornet\\kornelu01",
+  "Player": "Luke Kornet",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kornelu01.jpg",
   "WS": "0.4",
-  "salary": "$2401537",
+  "salary": "2401537.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d94b"
+    "$oid": "62850368cd0631716c143ce4"
   },
   "Rk": 316,
-  "Player": "Vit Krejci\\krejcvi01",
+  "Player": "Vit Krejci",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/krejcvi01.jpg",
   "WS": "0.6",
-  "salary": "$2401537",
+  "salary": "2401537.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d94c"
+    "$oid": "62850368cd0631716c143ce5"
   },
   "Rk": 317,
-  "Player": "Arnoldas Kulboka\\kulboar01",
+  "Player": "Arnoldas Kulboka",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kulboar01.jpg",
   "WS": "0",
-  "salary": "$2401537",
-  "playerTeam": "CHO"
+  "salary": "2401537.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d94d"
+    "$oid": "62850368cd0631716c143ce6"
   },
   "Rk": 318,
-  "Player": "Jonathan KuMinnesota Timberwolvesga\\kuMinnesota Timberwolvesjo01",
+  "Player": "Jonathan Kuminga",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kuminjo01.jpg",
   "WS": "3",
-  "salary": "$2401537",
+  "salary": "2401537.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d94e"
+    "$oid": "62850368cd0631716c143ce7"
   },
   "Rk": 319,
-  "Player": "Kyle Kuzma\\kuzmaky01",
+  "Player": "Kyle Kuzma",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/kuzmaky01.jpg",
   "WS": "2",
-  "salary": "$7310000",
-  "projSalary": "$5155000",
+  "salary": "7310000.00",
+  "projSalary": "5155000.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d94f"
+    "$oid": "62850368cd0631716c143ce8"
   },
   "Rk": 320,
-  "Player": "Anthony Lamb\\lamban01",
+  "Player": "Anthony Lamb",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lamban01.jpg",
   "WS": "0",
-  "salary": "$2389641",
+  "salary": "2389641.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d950"
+    "$oid": "62850368cd0631716c143ce9"
   },
   "Rk": 321,
-  "Player": "Jeremy Lamb\\lambje01",
+  "Player": "Jeremy Lamb",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lambje01.jpg",
   "WS": "1.2",
-  "salary": "$2389641",
+  "salary": "2389641.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d951"
+    "$oid": "62850368cd0631716c143cea"
   },
   "Rk": 322,
-  "Player": "Jock LanDallas Maverickse\\landajo01",
+  "Player": "Jock Landale",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/landajo01.jpg",
   "WS": "1.5",
-  "salary": "$2389641",
+  "salary": "2389641.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d952"
+    "$oid": "62850368cd0631716c143ceb"
   },
   "Rk": 323,
-  "Player": "Romeo Langford\\langfro01",
+  "Player": "Romeo Langford",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/langfro01.jpg",
   "WS": "1.3",
-  "salary": "$2389641",
+  "salary": "2389641.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d953"
+    "$oid": "62850368cd0631716c143cec"
   },
   "Rk": 324,
-  "Player": "Zach LaVine\\lavinza01",
+  "Player": "Zach LaVine",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lavinza01.jpg",
   "WS": "5.8",
-  "salary": "$2389641",
+  "salary": "2389641.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d954"
+    "$oid": "62850368cd0631716c143ced"
   },
   "Rk": 325,
-  "Player": "Jake Layman\\laymaja01",
+  "Player": "Jake Layman",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/laymaja01.jpg",
   "WS": "0.1",
-  "salary": "$5256308",
-  "projSalary": "$2866667",
+  "salary": "5256308.00",
+  "projSalary": "2866667.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d955"
+    "$oid": "62850368cd0631716c143cee"
   },
   "Rk": 326,
-  "Player": "Damion Lee\\leeda03",
+  "Player": "Damion Lee",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/leeda03.jpg",
   "WS": "2.7",
-  "salary": "$2389641",
+  "salary": "2389641.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d956"
+    "$oid": "62850368cd0631716c143cef"
   },
   "Rk": 327,
-  "Player": "Saben Lee\\leesa01",
+  "Player": "Saben Lee",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/leesa01.jpg",
   "WS": "0.9",
-  "salary": "$2353320",
-  "projSalary": "$2471160",
+  "salary": "2353320.00",
+  "projSalary": "2471160.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d957"
+    "$oid": "62850368cd0631716c143cf0"
   },
   "Rk": 328,
-  "Player": "Alex Len\\lenal01",
+  "Player": "Alex Len",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lenal01.jpg",
   "WS": "0.9",
-  "salary": "$2353320",
-  "projSalary": "$2471160",
+  "salary": "2353320.00",
+  "projSalary": "2471160.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d958"
+    "$oid": "62850368cd0631716c143cf1"
   },
   "Rk": 329,
-  "Player": "Caris LeVert\\leverca01",
+  "Player": "Caris LeVert",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/leverca01.jpg",
   "WS": "2.2",
-  "salary": "$2327220",
-  "projSalary": "$2443581",
+  "salary": "2327220.00",
+  "projSalary": "2443581.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d959"
+    "$oid": "62850368cd0631716c143cf2"
   },
   "Rk": 330,
-  "Player": "Kira Lewis Jr.\\lewiski01",
+  "Player": "Kira Lewis Jr.",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lewiski01.jpg",
   "WS": "-0.1",
-  "salary": "$2316240",
-  "projSalary": "$4171548",
-  "playerTeam": "NOP"
+  "salary": "2316240.00",
+  "projSalary": "4171548.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d95a"
+    "$oid": "62850368cd0631716c143cf3"
   },
   "Rk": 331,
-  "Player": "Scottie Lewis\\lewissc01",
+  "Player": "Scottie Lewis",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lewissc01.jpg",
   "WS": "0",
-  "salary": "$2303040",
-  "projSalary": "$2412840",
-  "playerTeam": "CHO"
+  "salary": "2303040.00",
+  "projSalary": "2412840.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d95b"
+    "$oid": "62850368cd0631716c143cf4"
   },
   "Rk": 332,
-  "Player": "DaMiami Heatn Lillard\\lillada01",
+  "Player": "Damian Lillard",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lillada01.jpg",
   "WS": "1.7",
-  "salary": "$2259240",
-  "projSalary": "$2372160",
+  "salary": "2259240.00",
+  "projSalary": "2372160.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d95c"
+    "$oid": "62850368cd0631716c143cf5"
   },
   "Rk": 333,
-  "Player": "Nassir Little\\littlna01",
+  "Player": "Nassir Little",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/littlna01.jpg",
   "WS": "1.7",
-  "salary": "$2245400",
+  "salary": "2245400.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d95d"
+    "$oid": "62850368cd0631716c143cf6"
   },
   "Rk": 334,
-  "Player": "Isaiah Livers\\liveris01",
+  "Player": "Isaiah Livers",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/liveris01.jpg",
   "WS": "0.7",
-  "salary": "$2239544",
+  "salary": "2239544.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d95e"
+    "$oid": "62850368cd0631716c143cf7"
   },
   "Rk": 335,
-  "Player": "Kevon Looney\\looneke01",
+  "Player": "Kevon Looney",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/looneke01.jpg",
   "WS": "6.8",
-  "salary": "$2239544",
+  "salary": "2239544.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d95f"
+    "$oid": "62850368cd0631716c143cf8"
   },
   "Rk": 336,
-  "Player": "Brook Lopez\\lopezbr01",
+  "Player": "Brook Lopez",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lopezbr01.jpg",
   "WS": "0.7",
-  "salary": "$2239200",
-  "projSalary": "$4037278",
+  "salary": "2239200.00",
+  "projSalary": "4037278.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d960"
+    "$oid": "62850368cd0631716c143cf9"
   },
   "Rk": 337,
-  "Player": "Robin Lopez\\lopezro01",
+  "Player": "Robin Lopez",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lopezro01.jpg",
   "WS": "0.8",
-  "salary": "$2210640",
-  "projSalary": "$2316240",
+  "salary": "2210640.00",
+  "projSalary": "2316240.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d961"
+    "$oid": "62850368cd0631716c143cfa"
   },
   "Rk": 338,
-  "Player": "Didi Louzada\\louzama01",
+  "Player": "Didi Louzada",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/louzama01.jpg",
   "WS": "0",
-  "salary": "$2197674",
-  "projSalary": "$2302326",
+  "salary": "2197674.00",
+  "projSalary": "2302326.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d962"
+    "$oid": "62850368cd0631716c143cfb"
   },
   "Rk": 339,
-  "Player": "Kevin Love\\loveke01",
+  "Player": "Kevin Love",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/loveke01.jpg",
   "WS": "5.7",
-  "salary": "$2168760",
-  "projSalary": "$2277000",
+  "salary": "2168760.00",
+  "projSalary": "2277000.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d963"
+    "$oid": "62850368cd0631716c143cfc"
   },
   "Rk": 340,
-  "Player": "Kyle Lowry\\lowryky01",
+  "Player": "Kyle Lowry",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lowryky01.jpg",
   "WS": "6.4",
-  "salary": "$2161440",
-  "projSalary": "$3901399",
+  "salary": "2161440.00",
+  "projSalary": "3901399.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d964"
+    "$oid": "62850368cd0631716c143cfd"
   },
   "Rk": 341,
-  "Player": "Gabriel Lundberg\\lundbga01",
+  "Player": "Gabriel Lundberg",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lundbga01.jpg",
   "WS": "0",
-  "salary": "$2161152",
+  "salary": "2161152.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d965"
+    "$oid": "62850368cd0631716c143cfe"
   },
   "Rk": 342,
-  "Player": "Timothé Luwawu-Cabarrot\\luwawti01",
+  "Player": "Timothé Luwawu-Cabarrot",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/luwawti01.jpg",
   "WS": "0.9",
-  "salary": "$2145720",
-  "projSalary": "$3873025",
+  "salary": "2145720.00",
+  "projSalary": "3873025.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d966"
+    "$oid": "62850368cd0631716c143cff"
   },
   "Rk": 343,
-  "Player": "Trey Lyles\\lylestr01",
+  "Player": "Trey Lyles",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/lylestr01.jpg",
   "WS": "3.5",
-  "salary": "$2137440",
-  "projSalary": "$2239200",
+  "salary": "2137440.00",
+  "projSalary": "2239200.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d967"
+    "$oid": "62850368cd0631716c143d00"
   },
   "Rk": 344,
-  "Player": "Théo Maledon\\maledth01",
+  "Player": "Théo Maledon",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/maledth01.jpg",
   "WS": "0.3",
-  "salary": "$2130240",
-  "projSalary": "$3845083",
+  "salary": "2130240.00",
+  "projSalary": "3845083.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d968"
+    "$oid": "62850368cd0631716c143d01"
   },
   "Rk": 345,
-  "Player": "Sandro Mamukelashvili\\mamuksa01",
+  "Player": "Sandro Mamukelashvili",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mamuksa01.jpg",
   "WS": "1.1",
-  "salary": "$2096880",
-  "projSalary": "$2201400",
+  "salary": "2096880.00",
+  "projSalary": "2201400.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d969"
+    "$oid": "62850368cd0631716c143d02"
   },
   "Rk": 346,
-  "Player": "Terance Mann\\mannte01",
+  "Player": "Terance Mann",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mannte01.jpg",
   "WS": "5.5",
-  "salary": "$2089448",
+  "salary": "2089448.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d96a"
+    "$oid": "62850368cd0631716c143d03"
   },
   "Rk": 347,
-  "Player": "Tre Mann\\manntr01",
+  "Player": "Tre Mann",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/manntr01.jpg",
   "WS": "0.1",
-  "salary": "$2089448",
+  "salary": "2089448.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d96b"
+    "$oid": "62850368cd0631716c143d04"
   },
   "Rk": 348,
-  "Player": "Boban Marjanović\\marjabo01",
+  "Player": "Boban Marjanović",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/marjabo01.jpg",
   "WS": "0.1",
-  "salary": "$2089448",
+  "salary": "2089448.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d96c"
+    "$oid": "62850368cd0631716c143d05"
   },
   "Rk": 349,
-  "Player": "Lauri Markkanen\\markkla01",
+  "Player": "Lauri Markkanen",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/markkla01.jpg",
   "WS": "5",
-  "salary": "$2075880",
-  "projSalary": "$2174880",
+  "salary": "2075880.00",
+  "projSalary": "2174880.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d96d"
+    "$oid": "62850368cd0631716c143d06"
   },
   "Rk": 350,
-  "Player": "Naji Marshall\\marshna01",
+  "Player": "Naji Marshall",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/marshna01.jpg",
   "WS": "0.8",
-  "salary": "$2063280",
-  "projSalary": "$2161440",
-  "playerTeam": "NOP"
+  "salary": "2063280.00",
+  "projSalary": "2161440.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d96e"
+    "$oid": "62850368cd0631716c143d07"
   },
   "Rk": 351,
-  "Player": "Caleb Martin\\martica02",
+  "Player": "Caleb Martin",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/martica02.jpg",
   "WS": "4",
-  "salary": "$2048040",
-  "projSalary": "$2145720",
+  "salary": "2048040.00",
+  "projSalary": "2145720.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d96f"
+    "$oid": "62850368cd0631716c143d08"
   },
   "Rk": 352,
-  "Player": "Cody Martin\\martico01",
+  "Player": "Cody Martin",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/martico01.jpg",
   "WS": "3.9",
-  "salary": "$2036280",
-  "projSalary": "$2138160",
-  "playerTeam": "CHO"
+  "salary": "2036280.00",
+  "projSalary": "2138160.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d970"
+    "$oid": "62850368cd0631716c143d09"
   },
   "Rk": 353,
-  "Player": "Kelan Martin\\martike03",
+  "Player": "Kelan Martin",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/martike03.jpg",
   "WS": "0",
-  "salary": "$2033160",
-  "projSalary": "$2130240",
+  "salary": "2033160.00",
+  "projSalary": "2130240.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d971"
+    "$oid": "62850368cd0631716c143d0a"
   },
   "Rk": 354,
-  "Player": "Kenyon Martin Jr.\\martike04",
+  "Player": "Kenyon Martin Jr.",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/martike04.jpg",
   "WS": "2.9",
-  "salary": "$2023800",
-  "projSalary": "$2125200",
+  "salary": "2023800.00",
+  "projSalary": "2125200.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d972"
+    "$oid": "62850368cd0631716c143d0b"
   },
   "Rk": 355,
-  "Player": "Garrison Mathews\\mathega01",
+  "Player": "Garrison Mathews",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mathega01.jpg",
   "WS": "2.8",
-  "salary": "$2009040",
-  "projSalary": "$2109360",
+  "salary": "2009040.00",
+  "projSalary": "2109360.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d973"
+    "$oid": "62850368cd0631716c143d0c"
   },
   "Rk": 356,
-  "Player": "Dakota Mathias\\mathida01",
+  "Player": "Dakota Mathias",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mathida01.jpg",
   "WS": "0",
-  "salary": "$2000000",
-  "projSalary": "$2000000",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "2000000.00",
+  "projSalary": "2000000.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d974"
+    "$oid": "62850368cd0631716c143d0d"
   },
   "Rk": 357,
-  "Player": "Wesley Matthews\\matthwe02",
+  "Player": "Wesley Matthews",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/matthwe02.jpg",
   "WS": "1.2",
-  "salary": "$2000000",
-  "projSalary": "$2000000",
+  "salary": "2000000.00",
+  "projSalary": "2000000.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d975"
+    "$oid": "62850368cd0631716c143d0e"
   },
   "Rk": 358,
-  "Player": "Tyrese Maxey\\maxeyty01",
+  "Player": "Tyrese Maxey",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/maxeyty01.jpg",
   "WS": "7.3",
-  "salary": "$2000000",
+  "salary": "2000000.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d976"
+    "$oid": "62850368cd0631716c143d0f"
   },
   "Rk": 359,
-  "Player": "Skylar Mays\\mayssk01",
+  "Player": "Skylar Mays",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mayssk01.jpg",
   "WS": "0.3",
-  "salary": "$2000000",
-  "projSalary": "$1900000",
+  "salary": "2000000.00",
+  "projSalary": "1900000.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d977"
+    "$oid": "62850368cd0631716c143d10"
   },
   "Rk": 360,
-  "Player": "Milwaukee Buckses McBride\\mcbrimi01",
+  "Player": "Miles McBride",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mcbrimi01.jpg",
   "WS": "0.2",
-  "salary": "$2000000",
-  "projSalary": "$2000000",
+  "salary": "2000000.00",
+  "projSalary": "2000000.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d978"
+    "$oid": "62850368cd0631716c143d11"
   },
   "Rk": 361,
-  "Player": "Mac McClung\\mccluma01",
+  "Player": "Mac McClung",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mccluma01.jpg",
   "WS": "0",
-  "salary": "$1994520",
-  "projSalary": "$2094240",
+  "salary": "1994520.00",
+  "projSalary": "2094240.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d979"
+    "$oid": "62850368cd0631716c143d12"
   },
   "Rk": 362,
-  "Player": "CJ McCollum\\mccolcj01",
+  "Player": "CJ McCollum",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mccolcj01.jpg",
   "WS": "3.6",
-  "salary": "$1977011",
+  "salary": "1977011.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d97a"
+    "$oid": "62850368cd0631716c143d13"
   },
   "Rk": 363,
-  "Player": "T.J. McConnell\\mccontj01",
+  "Player": "T.J. McConnell",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mccontj01.jpg",
   "WS": "1.3",
-  "salary": "$1958501",
+  "salary": "1958501.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d97b"
+    "$oid": "62850368cd0631716c143d14"
   },
   "Rk": 364,
-  "Player": "JaDenver Nuggets McDaniels\\mcdanja02",
+  "Player": "Jaden McDaniels",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mcdanja02.jpg",
   "WS": "2.4",
-  "salary": "$1939350",
+  "salary": "1939350.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d97c"
+    "$oid": "62850368cd0631716c143d15"
   },
   "Rk": 365,
-  "Player": "Jalen McDaniels\\mcdanja01",
+  "Player": "Jalen McDaniels",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mcdanja01.jpg",
   "WS": "1.7",
-  "salary": "$2541217",
-  "playerTeam": "CHO"
+  "salary": "2541217.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d97d"
+    "$oid": "62850368cd0631716c143d16"
   },
   "Rk": 366,
-  "Player": "Doug McDermott\\mcderdo01",
+  "Player": "Doug McDermott",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mcderdo01.jpg",
   "WS": "1.6",
-  "salary": "$1939350",
+  "salary": "1939350.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d97e"
+    "$oid": "62850368cd0631716c143d17"
   },
   "Rk": 367,
-  "Player": "JaVale McGee\\mcgeeja01",
+  "Player": "JaVale McGee",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mcgeeja01.jpg",
   "WS": "4.9",
-  "salary": "$1939350",
+  "salary": "1939350.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d97f"
+    "$oid": "62850368cd0631716c143d18"
   },
   "Rk": 368,
-  "Player": "Cameron McGriff\\mcgrica01",
+  "Player": "Cameron McGriff",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mcgrica01.jpg",
   "WS": "0.1",
-  "salary": "$1910860",
+  "salary": "1910860.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d980"
+    "$oid": "62850368cd0631716c143d19"
   },
   "Rk": 369,
-  "Player": "Rodney McGruder\\mcgruro01",
+  "Player": "Rodney McGruder",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mcgruro01.jpg",
   "WS": "1.2",
-  "salary": "$1910860",
+  "salary": "1910860.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d981"
+    "$oid": "62850368cd0631716c143d1a"
   },
   "Rk": 370,
-  "Player": "Alfonzo McKinnie\\mckinal01",
+  "Player": "Alfonzo McKinnie",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mckinal01.jpg",
   "WS": "-0.1",
-  "salary": "$1865547",
+  "salary": "1865547.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d982"
+    "$oid": "62850368cd0631716c143d1b"
   },
   "Rk": 371,
-  "Player": "JaQuori McLaughlin\\mclauja01",
+  "Player": "JaQuori McLaughlin",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mclauja01.jpg",
   "WS": "0",
-  "salary": "$1846738",
-  "projSalary": "$1997718",
+  "salary": "1846738.00",
+  "projSalary": "1997718.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d983"
+    "$oid": "62850368cd0631716c143d1c"
   },
   "Rk": 372,
-  "Player": "Jordan McLaughlin\\mclaujo01",
+  "Player": "Jordan McLaughlin",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mclaujo01.jpg",
   "WS": "2.3",
-  "salary": "$1802057",
+  "salary": "1802057.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d984"
+    "$oid": "62850368cd0631716c143d1d"
   },
   "Rk": 373,
-  "Player": "Ben MCleveland Cavaliersmore\\mCleveland Cavaliersmbe01",
+  "Player": "Ben McLemore",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mclembe01.jpg",
   "WS": "0.8",
-  "salary": "$1802057",
+  "salary": "1802057.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d985"
+    "$oid": "62850368cd0631716c143d1e"
   },
   "Rk": 374,
-  "Player": "De'Anthony Melton\\meltode01",
+  "Player": "De'Anthony Melton",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/meltode01.jpg",
   "WS": "3.7",
-  "salary": "$1789256",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "1789256.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d986"
+    "$oid": "62850368cd0631716c143d1f"
   },
   "Rk": 375,
-  "Player": "Sam Merrill\\merrisa01",
+  "Player": "Sam Merrill",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/merrisa01.jpg",
   "WS": "0",
-  "salary": "$1789256",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "1789256.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d987"
+    "$oid": "62850368cd0631716c143d20"
   },
   "Rk": 376,
-  "Player": "Chicago Bullsmezie Metu\\metuch01",
+  "Player": "Chimezie Metu",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/metuch01.jpg",
   "WS": "1.5",
-  "salary": "$1789256",
+  "salary": "1789256.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d988"
+    "$oid": "62850368cd0631716c143d21"
   },
   "Rk": 377,
-  "Player": "Khris Middleton\\middlkh01",
+  "Player": "Khris Middleton",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/middlkh01.jpg",
   "WS": "5.3",
-  "salary": "$1789256",
-  "projSalary": "$2036318",
+  "salary": "1789256.00",
+  "projSalary": "2036318.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d989"
+    "$oid": "62850368cd0631716c143d22"
   },
   "Rk": 378,
-  "Player": "C.J. Milwaukee Buckses\\Milwaukee Bucksescj01",
+  "Player": "C.J. Miles",
   "age": 34,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/milescj01.jpg",
   "WS": "0",
-  "salary": "$1789256",
-  "projSalary": "$2036318",
+  "salary": "1789256.00",
+  "projSalary": "2036318.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d98a"
+    "$oid": "62850368cd0631716c143d23"
   },
   "Rk": 379,
-  "Player": "Patty Milwaukee Bucksls\\Milwaukee Buckslspa02",
+  "Player": "Patty Mills",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/millspa02.jpg",
   "WS": "2.8",
-  "salary": "$1786878",
-  "projSalary": "$1876222",
-  "playerTeam": "BRK"
+  "salary": "1786878.00",
+  "projSalary": "1876222.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d98b"
+    "$oid": "62850368cd0631716c143d24"
   },
   "Rk": 380,
-  "Player": "Paul Milwaukee Buckslsap\\Milwaukee Buckslspa01",
+  "Player": "Paul Millsap",
   "age": 36,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/millspa01.jpg",
   "WS": "0.5",
-  "salary": "$1782621",
-  "projSalary": "$1930681",
+  "salary": "1782621.00",
+  "projSalary": "1930681.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d98c"
+    "$oid": "62850368cd0631716c143d25"
   },
   "Rk": 381,
-  "Player": "Shake Milwaukee Buckston\\Milwaukee Buckstosh01",
+  "Player": "Shake Milton",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/miltosh01.jpg",
   "WS": "1.7",
-  "salary": "$1782621",
-  "projSalary": "$1930681",
+  "salary": "1782621.00",
+  "projSalary": "1930681.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d98d"
+    "$oid": "62850368cd0631716c143d26"
   },
   "Rk": 382,
-  "Player": "Davion Mitchell\\mitchda01",
+  "Player": "Davion Mitchell",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mitchda01.jpg",
   "WS": "0.1",
-  "salary": "$1782621",
+  "salary": "1782621.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d98e"
+    "$oid": "62850368cd0631716c143d27"
   },
   "Rk": 383,
-  "Player": "Donovan Mitchell\\mitchdo01",
+  "Player": "Donovan Mitchell",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mitchdo01.jpg",
   "WS": "7.2",
-  "salary": "$1782621",
+  "salary": "1782621.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d98f"
+    "$oid": "62850368cd0631716c143d28"
   },
   "Rk": 384,
-  "Player": "Evan Mobley\\mobleev01",
+  "Player": "Evan Mobley",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mobleev01.jpg",
   "WS": "5.2",
-  "salary": "$76744",
-  "projSalary": "$1815677",
+  "salary": "76744.00",
+  "projSalary": "1815677.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d990"
+    "$oid": "62850368cd0631716c143d29"
   },
   "Rk": 385,
-  "Player": "Malik Monk\\monkma01",
+  "Player": "Malik Monk",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/monkma01.jpg",
   "WS": "3.6",
-  "salary": "$1782621",
+  "salary": "1782621.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d991"
+    "$oid": "62850368cd0631716c143d2a"
   },
   "Rk": 386,
-  "Player": "Greg Monroe\\monrogr01",
+  "Player": "Greg Monroe",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/monrogr01.jpg",
   "WS": "0.7",
-  "salary": "$1782621",
+  "salary": "1782621.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d992"
+    "$oid": "62850368cd0631716c143d2b"
   },
   "Rk": 387,
-  "Player": "Moses Moody\\moodymo01",
+  "Player": "Moses Moody",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/moodymo01.jpg",
   "WS": "1.3",
-  "salary": "$1782621",
+  "salary": "1782621.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d993"
+    "$oid": "62850368cd0631716c143d2c"
   },
   "Rk": 388,
-  "Player": "Xavier Moon\\moonxa01",
+  "Player": "Xavier Moon",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/moonxa01.jpg",
   "WS": "0.3",
-  "salary": "$1782621",
-  "projSalary": "$1930681",
+  "salary": "1782621.00",
+  "projSalary": "1930681.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d994"
+    "$oid": "62850368cd0631716c143d2d"
   },
   "Rk": 389,
-  "Player": "Matt Mooney\\moonema01",
+  "Player": "Matt Mooney",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/moonema01.jpg",
   "WS": "0",
-  "salary": "$1782621",
-  "projSalary": "$1930681",
+  "salary": "1782621.00",
+  "projSalary": "1930681.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d995"
+    "$oid": "62850368cd0631716c143d2e"
   },
   "Rk": 390,
-  "Player": "Ja Morant\\moranja01",
+  "Player": "Ja Morant",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/moranja01.jpg",
   "WS": "6.7",
-  "salary": "$1782621",
-  "projSalary": "$1930681",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "1782621.00",
+  "projSalary": "1930681.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d996"
+    "$oid": "62850368cd0631716c143d2f"
   },
   "Rk": 391,
-  "Player": "Juwan Morgan\\morgaju01",
+  "Player": "Juwan Morgan",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/morgaju01.jpg",
   "WS": "0.1",
-  "salary": "$1782621",
-  "projSalary": "$1930681",
+  "salary": "1782621.00",
+  "projSalary": "1930681.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d997"
+    "$oid": "62850368cd0631716c143d30"
   },
   "Rk": 392,
-  "Player": "Jaylen Morris\\morrija01",
+  "Player": "Jaylen Morris",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/morrija01.jpg",
   "WS": "-0.1",
-  "salary": "$1782621",
+  "salary": "1782621.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d998"
+    "$oid": "62850368cd0631716c143d31"
   },
   "Rk": 393,
-  "Player": "Marcus Morris\\morrima03",
+  "Player": "Marcus Morris",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/morrima03.jpg",
   "WS": "2.4",
-  "salary": "$1782621",
-  "projSalary": "$1930681",
+  "salary": "1782621.00",
+  "projSalary": "1930681.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d999"
+    "$oid": "62850368cd0631716c143d32"
   },
   "Rk": 394,
-  "Player": "Markieff Morris\\morrima02",
+  "Player": "Markieff Morris",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/morrima02.jpg",
   "WS": "0.3",
-  "salary": "$1782621",
-  "projSalary": "$1930681",
+  "salary": "1782621.00",
+  "projSalary": "1930681.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d99a"
+    "$oid": "62850368cd0631716c143d33"
   },
   "Rk": 395,
-  "Player": "Monte Morris\\morrimo01",
+  "Player": "Monte Morris",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/morrimo01.jpg",
   "WS": "5.4",
-  "salary": "$1762796",
+  "salary": "1762796.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d99b"
+    "$oid": "62850368cd0631716c143d34"
   },
   "Rk": 396,
-  "Player": "Emmanuel Mudiay\\mudiaem01",
+  "Player": "Emmanuel Mudiay",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mudiaem01.jpg",
   "WS": "0",
-  "salary": "$1762796",
-  "projSalary": "$1910860",
+  "salary": "1762796.00",
+  "projSalary": "1910860.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d99c"
+    "$oid": "62850368cd0631716c143d35"
   },
   "Rk": 397,
-  "Player": "MyCharlotte Hornetsl Mulder\\muldemy01",
+  "Player": "Mychal Mulder",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/muldemy01.jpg",
   "WS": "-0.2",
-  "salary": "$1762769",
+  "salary": "1762769.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d99d"
+    "$oid": "62850368cd0631716c143d36"
   },
   "Rk": 398,
-  "Player": "Ade Murkey\\murkead01",
+  "Player": "Ade Murkey",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/murkead01.jpg",
   "WS": "0",
-  "salary": "$1729217",
-  "projSalary": "$1878720",
+  "salary": "1729217.00",
+  "projSalary": "1878720.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d99e"
+    "$oid": "62850368cd0631716c143d37"
   },
   "Rk": 399,
-  "Player": "Trey Murphy III\\murphtr02",
+  "Player": "Trey Murphy III",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/murphtr02.jpg",
   "WS": "1.9",
-  "salary": "$1729217",
-  "projSalary": "$1878720",
-  "playerTeam": "NOP"
+  "salary": "1729217.00",
+  "projSalary": "1878720.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d99f"
+    "$oid": "62850368cd0631716c143d38"
   },
   "Rk": 400,
-  "Player": "Dejounte Murray\\murrade01",
+  "Player": "Dejounte Murray",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/murrade01.jpg",
   "WS": "7.3",
-  "salary": "$1729217",
-  "projSalary": "$1878720",
+  "salary": "1729217.00",
+  "projSalary": "1878720.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a0"
+    "$oid": "62850368cd0631716c143d39"
   },
   "Rk": 401,
-  "Player": "Mike Muscala\\muscami01",
+  "Player": "Mike Muscala",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/muscami01.jpg",
   "WS": "2.1",
-  "salary": "$1729217",
-  "projSalary": "$1878720",
+  "salary": "1729217.00",
+  "projSalary": "1878720.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a1"
+    "$oid": "62850368cd0631716c143d3a"
   },
   "Rk": 402,
-  "Player": "Svi Mykhailiuk\\mykhasv01",
+  "Player": "Svi Mykhailiuk",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/mykhasv01.jpg",
   "WS": "0.8",
-  "salary": "$1729217",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "1729217.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a2"
+    "$oid": "62850368cd0631716c143d3b"
   },
   "Rk": 403,
-  "Player": "Abdel Nader\\naderab01",
+  "Player": "Abdel Nader",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/naderab01.jpg",
   "WS": "0",
-  "salary": "$3430810",
+  "salary": "3430810.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a3"
+    "$oid": "62850368cd0631716c143d3c"
   },
   "Rk": 404,
-  "Player": "Larry Nance Jr.\\nancela02",
+  "Player": "Larry Nance Jr.",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nancela02.jpg",
   "WS": "2.3",
-  "salary": "$1701593",
+  "salary": "1701593.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a4"
+    "$oid": "62850368cd0631716c143d3d"
   },
   "Rk": 405,
-  "Player": "RJ Nembhard Jr.\\nembhrj01",
+  "Player": "RJ Nembhard Jr.",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nembhrj01.jpg",
   "WS": "0",
-  "salary": "$1720779",
+  "salary": "1720779.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a5"
+    "$oid": "62850368cd0631716c143d3e"
   },
   "Rk": 406,
-  "Player": "Aaron Nesmith\\nesMiami Heata01",
+  "Player": "Aaron Nesmith",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nesmiaa01.jpg",
   "WS": "0.4",
-  "salary": "$1701593",
-  "projSalary": "$1846738",
+  "salary": "1701593.00",
+  "projSalary": "1846738.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a6"
+    "$oid": "62850368cd0631716c143d3f"
   },
   "Rk": 407,
-  "Player": "Raul Neto\\neToronto Raptorssa01",
+  "Player": "Raul Neto",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/netora01.jpg",
   "WS": "1.5",
-  "salary": "$3430810",
+  "salary": "3430810.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a7"
+    "$oid": "62850368cd0631716c143d40"
   },
   "Rk": 408,
-  "Player": "Malik Newman\\newmama01",
+  "Player": "Malik Newman",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/newmama01.jpg",
   "WS": "0",
-  "salary": "$1700000",
-  "projSalary": "$1785000",
+  "salary": "1700000.00",
+  "projSalary": "1785000.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a8"
+    "$oid": "62850368cd0631716c143d41"
   },
   "Rk": 409,
-  "Player": "Georges Niang\\niangge01",
+  "Player": "Georges Niang",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/niangge01.jpg",
   "WS": "2.8",
-  "salary": "$1690507",
+  "salary": "1690507.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9a9"
+    "$oid": "62850368cd0631716c143d42"
   },
   "Rk": 410,
-  "Player": "Daishen Nix\\nixda01",
+  "Player": "Daishen Nix",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nixda01.jpg",
   "WS": "-0.2",
-  "salary": "$1669178",
-  "projSalary": "$1815677",
+  "salary": "1669178.00",
+  "projSalary": "1815677.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9aa"
+    "$oid": "62850368cd0631716c143d43"
   },
   "Rk": 411,
-  "Player": "Zeke Nnaji\\nnajize01",
+  "Player": "Zeke Nnaji",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nnajize01.jpg",
   "WS": "1.8",
-  "salary": "$1669178",
-  "projSalary": "$1815677",
+  "salary": "1669178.00",
+  "projSalary": "1815677.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ab"
+    "$oid": "62850368cd0631716c143d44"
   },
   "Rk": 412,
-  "Player": "Nerlens Noel\\noelne01",
+  "Player": "Nerlens Noel",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/noelne01.jpg",
   "WS": "1.5",
-  "salary": "$1669178",
-  "projSalary": "$1815677",
+  "salary": "1669178.00",
+  "projSalary": "1815677.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ac"
+    "$oid": "62850368cd0631716c143d45"
   },
   "Rk": 413,
-  "Player": "Jaylen Nowell\\nowelja01",
+  "Player": "Jaylen Nowell",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nowelja01.jpg",
   "WS": "2.8",
-  "salary": "$1669178",
-  "projSalary": "$1815677",
+  "salary": "1669178.00",
+  "projSalary": "1815677.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ad"
+    "$oid": "62850368cd0631716c143d46"
   },
   "Rk": 414,
-  "Player": "Frank Ntilikina\\ntilila01",
+  "Player": "Frank Ntilikina",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ntilila01.jpg",
   "WS": "0.9",
-  "salary": "$1669178",
+  "salary": "1669178.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ae"
+    "$oid": "62850368cd0631716c143d47"
   },
   "Rk": 415,
-  "Player": "Jusuf Nurkić\\nurkiju01",
+  "Player": "Jusuf Nurkić",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nurkiju01.jpg",
   "WS": "3.6",
-  "salary": "$1669178",
+  "salary": "1669178.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9af"
+    "$oid": "62850368cd0631716c143d48"
   },
   "Rk": 416,
-  "Player": "David Nwaba\\nwabada01",
+  "Player": "David Nwaba",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nwabada01.jpg",
   "WS": "1.3",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b0"
+    "$oid": "62850368cd0631716c143d49"
   },
   "Rk": 417,
-  "Player": "Jordan Nwora\\nworajo01",
+  "Player": "Jordan Nwora",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/nworajo01.jpg",
   "WS": "0.6",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b1"
+    "$oid": "62850368cd0631716c143d4a"
   },
   "Rk": 418,
-  "Player": "Royce O'Neale\\onealro01",
+  "Player": "Royce O'Neale",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/onealro01.jpg",
   "WS": "5.5",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b2"
+    "$oid": "62850368cd0631716c143d4b"
   },
   "Rk": 419,
-  "Player": "Semi Ojeleye\\ojelese01",
+  "Player": "Semi Ojeleye",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ojelese01.jpg",
   "WS": "0.2",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b3"
+    "$oid": "62850368cd0631716c143d4c"
   },
   "Rk": 420,
-  "Player": "Chuma Okeke\\okekech01",
+  "Player": "Chuma Okeke",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/okekech01.jpg",
   "WS": "2.2",
-  "salary": "$1517981",
+  "salary": "1517981.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b4"
+    "$oid": "62850368cd0631716c143d4d"
   },
   "Rk": 421,
-  "Player": "Josh Okogie\\okogijo01",
+  "Player": "Josh Okogie",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/okogijo01.jpg",
   "WS": "0.7",
-  "salary": "$1517981",
+  "salary": "1517981.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b5"
+    "$oid": "62850368cd0631716c143d4e"
   },
   "Rk": 422,
-  "Player": "Onyeka Okongwu\\okongon01",
+  "Player": "Onyeka Okongwu",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/okongon01.jpg",
   "WS": "4.2",
-  "salary": "$1517981",
+  "salary": "1517981.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b6"
+    "$oid": "62850368cd0631716c143d4f"
   },
   "Rk": 423,
-  "Player": "Isaac Okoro\\okorois01",
+  "Player": "Isaac Okoro",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/okorois01.jpg",
   "WS": "4.2",
-  "salary": "$1517981",
+  "salary": "1517981.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b7"
+    "$oid": "62850368cd0631716c143d50"
   },
   "Rk": 424,
-  "Player": "KZ Okpala\\okpalkz01",
+  "Player": "KZ Okpala",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/okpalkz01.jpg",
   "WS": "0.5",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b8"
+    "$oid": "62850368cd0631716c143d51"
   },
   "Rk": 425,
-  "Player": "VicToronto Raptorss Oladipo\\oladivi01",
+  "Player": "Victor Oladipo",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/oladivi01.jpg",
   "WS": "0.4",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9b9"
+    "$oid": "62850368cd0631716c143d52"
   },
   "Rk": 426,
-  "Player": "Cameron Oliver\\oliveca01",
+  "Player": "Cameron Oliver",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/oliveca01.jpg",
   "WS": "0.2",
-  "salary": "$1517981",
+  "salary": "1517981.00",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ba"
+    "$oid": "62850368cd0631716c143d53"
   },
   "Rk": 427,
-  "Player": "Kelly OlyNew York Knicks\\olyNew York Knickse01",
+  "Player": "Kelly Olynyk",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/olynyke01.jpg",
   "WS": "1.6",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9bb"
+    "$oid": "62850368cd0631716c143d54"
   },
   "Rk": 428,
-  "Player": "Eugene Omoruyi\\omorueu01",
+  "Player": "Eugene Omoruyi",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/omorueu01.jpg",
   "WS": "0.1",
-  "salary": "$1517981",
+  "salary": "1517981.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9bc"
+    "$oid": "62850368cd0631716c143d55"
   },
   "Rk": 429,
-  "Player": "Miye Oni\\onimi01",
+  "Player": "Miye Oni",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/onimi01.jpg",
   "WS": "0",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9bd"
+    "$oid": "62850368cd0631716c143d56"
   },
   "Rk": 430,
-  "Player": "Cedi Osman\\osmande01",
+  "Player": "Cedi Osman",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/osmande01.jpg",
   "WS": "2.9",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9be"
+    "$oid": "62850368cd0631716c143d57"
   },
   "Rk": 431,
-  "Player": "Daniel Oturu\\oturuda01",
+  "Player": "Daniel Oturu",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/oturuda01.jpg",
   "WS": "0.1",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9bf"
+    "$oid": "62850368cd0631716c143d58"
   },
   "Rk": 432,
-  "Player": "Kelly Oubre Jr.\\oubreke01",
+  "Player": "Kelly Oubre Jr.",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/oubreke01.jpg",
   "WS": "3.3",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
-  "playerTeam": "CHO"
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c0"
+    "$oid": "62850368cd0631716c143d59"
   },
   "Rk": 433,
-  "Player": "Jaysean Paige\\paigeja01",
+  "Player": "Jaysean Paige",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/paigeja01.jpg",
   "WS": "-0.1",
-  "salary": "$1500000",
-  "projSalary": "$1563518",
+  "salary": "1500000.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c1"
+    "$oid": "62850368cd0631716c143d5a"
   },
   "Rk": 434,
-  "Player": "Trayvon Palmer\\palmetr01",
+  "Player": "Trayvon Palmer",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/palmetr01.jpg",
   "WS": "0",
-  "salary": "$1500000",
-  "projSalary": "$1563518",
+  "salary": "1500000.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c2"
+    "$oid": "62850368cd0631716c143d5b"
   },
   "Rk": 435,
-  "Player": "Kevin Pangos\\pangoke01",
+  "Player": "Kevin Pangos",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/pangoke01.jpg",
   "WS": "0.1",
-  "salary": "$1489065",
-  "projSalary": "$1752638",
+  "salary": "1489065.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c3"
+    "$oid": "62850368cd0631716c143d5c"
   },
   "Rk": 436,
-  "Player": "Jabari Parker\\parkeja01",
+  "Player": "Jabari Parker",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/parkeja01.jpg",
   "WS": "0.3",
-  "salary": "$1489065",
-  "projSalary": "$1752638",
+  "salary": "1489065.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c4"
+    "$oid": "62850368cd0631716c143d5d"
   },
   "Rk": 437,
-  "Player": "Eric PasCharlotte Hornetsll\\pascher01",
+  "Player": "Eric Paschall",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/pascher01.jpg",
   "WS": "2",
-  "salary": "$1625991",
-  "projSalary": "$1752638",
+  "salary": "1625991.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c5"
+    "$oid": "62850368cd0631716c143d5e"
   },
   "Rk": 438,
-  "Player": "Chris Paul\\paulch01",
+  "Player": "Chris Paul",
   "age": 36,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/paulch01.jpg",
   "WS": "9.4",
-  "salary": "$1456666",
+  "salary": "1456666.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c6"
+    "$oid": "62850368cd0631716c143d5f"
   },
   "Rk": 439,
-  "Player": "Cameron Payne\\payneca01",
+  "Player": "Cameron Payne",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/payneca01.jpg",
   "WS": "1.9",
-  "salary": "$2045094",
+  "salary": "2045094.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c7"
+    "$oid": "62850368cd0631716c143d60"
   },
   "Rk": 440,
-  "Player": "Elfrid Payton\\paytoel01",
+  "Player": "Elfrid Payton",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/paytoel01.jpg",
   "WS": "-0.2",
-  "salary": "$1366392",
+  "salary": "1366392.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c8"
+    "$oid": "62850368cd0631716c143d61"
   },
   "Rk": 441,
-  "Player": "Gary Payton II\\paytoga02",
+  "Player": "Gary Payton II",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/paytoga02.jpg",
   "WS": "5.2",
-  "salary": "$4000000",
-  "projSalary": "$4000000",
+  "salary": "4000000.00",
+  "projSalary": "4000000.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9c9"
+    "$oid": "62850368cd0631716c143d62"
   },
   "Rk": 442,
-  "Player": "Norvel Pelle\\pelleno01",
+  "Player": "Norvel Pelle",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/pelleno01.jpg",
   "WS": "0",
-  "salary": "$1252127",
+  "salary": "1252127.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ca"
+    "$oid": "62850368cd0631716c143d63"
   },
   "Rk": 443,
-  "Player": "Reggie Perry\\perryre01",
+  "Player": "Reggie Perry",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/perryre01.jpg",
   "WS": "0.2",
-  "salary": "$1250000",
-  "projSalary": "$1563518",
+  "salary": "1250000.00",
+  "projSalary": "1563518.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9cb"
+    "$oid": "62850368cd0631716c143d64"
   },
   "Rk": 444,
-  "Player": "Jamorko Pickett\\pickeja01",
+  "Player": "Jamorko Pickett",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/pickeja01.jpg",
   "WS": "0.1",
-  "salary": "$1093598",
-  "projSalary": "$1815677",
+  "salary": "1093598.00",
+  "projSalary": "1815677.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9cc"
+    "$oid": "62850368cd0631716c143d65"
   },
   "Rk": 445,
-  "Player": "Theo Pinson\\pinsoth01",
+  "Player": "Theo Pinson",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/pinsoth01.jpg",
   "WS": "0.4",
-  "salary": "$1090007",
+  "salary": "1090007.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9cd"
+    "$oid": "62850368cd0631716c143d66"
   },
   "Rk": 446,
-  "Player": "Mason Plumlee\\plumlma01",
+  "Player": "Mason Plumlee",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/plumlma01.jpg",
   "WS": "4.7",
-  "salary": "$1068288",
-  "playerTeam": "CHO"
+  "salary": "1068288.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ce"
+    "$oid": "62850368cd0631716c143d67"
   },
   "Rk": 447,
-  "Player": "Jakob Poeltl\\poeltja01",
+  "Player": "Jakob Poeltl",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/poeltja01.jpg",
   "WS": "6.9",
-  "salary": "$1062303",
-  "projSalary": "$1563518",
+  "salary": "1062303.00",
+  "projSalary": "1563518.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9cf"
+    "$oid": "62850368cd0631716c143d68"
   },
   "Rk": 448,
-  "Player": "Aleksej Pokusevski\\pokusal01",
+  "Player": "Aleksej Pokusevski",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/pokusal01.jpg",
   "WS": "0.4",
-  "salary": "$1057260",
-  "projSalary": "$1563518",
+  "salary": "1057260.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d0"
+    "$oid": "62850368cd0631716c143d69"
   },
   "Rk": 449,
-  "Player": "Yves Pons\\ponsyv01",
+  "Player": "Yves Pons",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ponsyv01.jpg",
   "WS": "0",
-  "salary": "$1039080",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "1039080.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d1"
+    "$oid": "62850368cd0631716c143d6a"
   },
   "Rk": 450,
-  "Player": "Jordan Poole\\poolejo01",
+  "Player": "Jordan Poole",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/poolejo01.jpg",
   "WS": "6",
-  "salary": "$1000000",
-  "projSalary": "$1563518",
+  "salary": "1000000.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d2"
+    "$oid": "62850368cd0631716c143d6b"
   },
   "Rk": 451,
-  "Player": "Kevin Portland Trail Blazerster Jr.\\Portland Trail Blazersteke02",
+  "Player": "Kevin Porter Jr.",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/porteke02.jpg",
   "WS": "0.8",
-  "salary": "$10720900",
+  "salary": "10720900.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d3"
+    "$oid": "62850368cd0631716c143d6c"
   },
   "Rk": 452,
-  "Player": "MiCharlotte Hornetsel Portland Trail Blazerster Jr.\\Portland Trail Blazerstemi01",
+  "Player": "Michael Porter Jr.",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/portemi01.jpg",
   "WS": "-0.2",
-  "salary": "$999200",
-  "projSalary": "$999200",
+  "salary": "999200.00",
+  "projSalary": "999200.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d4"
+    "$oid": "62850368cd0631716c143d6d"
   },
   "Rk": 453,
-  "Player": "Otto Portland Trail Blazerster Jr.\\Portland Trail Blazersteot01",
+  "Player": "Otto Porter Jr.",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/porteot01.jpg",
   "WS": "4.9",
-  "salary": "$958529",
-  "projSalary": "$2193920",
+  "salary": "958529.00",
+  "projSalary": "2193920.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d5"
+    "$oid": "62850368cd0631716c143d6e"
   },
   "Rk": 454,
-  "Player": "Bobby Portland Trail Blazerstis\\Portland Trail Blazerstibo01",
+  "Player": "Bobby Portis",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/portibo01.jpg",
   "WS": "5.5",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d6"
+    "$oid": "62850368cd0631716c143d6f"
   },
   "Rk": 455,
-  "Player": "Kristaps Portland Trail Blazersziņģis\\Portland Trail Blazerszikr01",
+  "Player": "Kristaps Porziņģis",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/porzikr01.jpg",
   "WS": "5.6",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d7"
+    "$oid": "62850368cd0631716c143d70"
   },
   "Rk": 456,
-  "Player": "Micah Potter\\pottemi01",
+  "Player": "Micah Potter",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/pottemi01.jpg",
   "WS": "0",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d8"
+    "$oid": "62850368cd0631716c143d71"
   },
   "Rk": 457,
-  "Player": "Dwight Powell\\poweldw01",
+  "Player": "Dwight Powell",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/poweldw01.jpg",
   "WS": "8.2",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Dallas Mavericks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9d9"
+    "$oid": "62850368cd0631716c143d72"
   },
   "Rk": 458,
-  "Player": "Myles Powell\\powelmy01",
+  "Player": "Myles Powell",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/powelmy01.jpg",
   "WS": "-0.1",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9da"
+    "$oid": "62850368cd0631716c143d73"
   },
   "Rk": 459,
-  "Player": "Norman Powell\\powelno01",
+  "Player": "Norman Powell",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/powelno01.jpg",
   "WS": "2.8",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9db"
+    "$oid": "62850368cd0631716c143d74"
   },
   "Rk": 460,
-  "Player": "Joshua Primo\\primojo01",
+  "Player": "Joshua Primo",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/primojo01.jpg",
   "WS": "0",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9dc"
+    "$oid": "62850368cd0631716c143d75"
   },
   "Rk": 461,
-  "Player": "Taurean Prince\\princta02",
+  "Player": "Taurean Prince",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/princta02.jpg",
   "WS": "2.2",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9dd"
+    "$oid": "62850368cd0631716c143d76"
   },
   "Rk": 462,
-  "Player": "Payton PritCharlotte Hornetsrd\\pritcpa01",
+  "Player": "Payton Pritchard",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/pritcpa01.jpg",
   "WS": "3.1",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9de"
+    "$oid": "62850368cd0631716c143d77"
   },
   "Rk": 463,
-  "Player": "Trevelin Queen\\queentr01",
+  "Player": "Trevelin Queen",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/queentr01.jpg",
   "WS": "0.1",
-  "salary": "$925258",
-  "projSalary": "$1563518",
+  "salary": "925258.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9df"
+    "$oid": "62850368cd0631716c143d78"
   },
   "Rk": 464,
-  "Player": "NeeMiami Heats Queta\\quetane01",
+  "Player": "Neemia Queta",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/quetane01.jpg",
   "WS": "0.1",
-  "salary": "$925258",
+  "salary": "925258.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e0"
+    "$oid": "62850368cd0631716c143d79"
   },
   "Rk": 465,
-  "Player": "Immanuel Quickley\\quickim01",
+  "Player": "Immanuel Quickley",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/quickim01.jpg",
   "WS": "4.2",
-  "salary": "$925258",
+  "salary": "925258.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e1"
+    "$oid": "62850368cd0631716c143d7a"
   },
   "Rk": 466,
-  "Player": "Jahmi'us Ramsey\\ramseja01",
+  "Player": "Jahmi'us Ramsey",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ramseja01.jpg",
   "WS": "-0.1",
-  "salary": "$924730",
+  "salary": "924730.00",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e2"
+    "$oid": "62850368cd0631716c143d7b"
   },
   "Rk": 467,
-  "Player": "Julius Randle\\randlju01",
+  "Player": "Julius Randle",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/randlju01.jpg",
   "WS": "3.1",
-  "salary": "$888616",
-  "projSalary": "$2351521",
+  "salary": "888616.00",
+  "projSalary": "2351521.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e3"
+    "$oid": "62850368cd0631716c143d7c"
   },
   "Rk": 468,
-  "Player": "Austin Reaves\\reaveau01",
+  "Player": "Austin Reaves",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/reaveau01.jpg",
   "WS": "2.9",
-  "salary": "$850331",
+  "salary": "850331.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e4"
+    "$oid": "62850368cd0631716c143d7d"
   },
   "Rk": 469,
-  "Player": "Cam Reddish\\reddica01",
+  "Player": "Cam Reddish",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/reddica01.jpg",
   "WS": "1",
-  "salary": "$785102",
+  "salary": "785102.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e5"
+    "$oid": "62850368cd0631716c143d7e"
   },
   "Rk": 470,
-  "Player": "Davon Reed\\reedda01",
+  "Player": "Davon Reed",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/reedda01.jpg",
   "WS": "1.6",
-  "salary": "$20168742",
+  "salary": "20168742.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e6"
+    "$oid": "62850368cd0631716c143d7f"
   },
   "Rk": 471,
-  "Player": "Paul Reed\\reedpa01",
+  "Player": "Paul Reed",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/reedpa01.jpg",
   "WS": "1.3",
-  "salary": "$705598",
+  "salary": "705598.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e7"
+    "$oid": "62850368cd0631716c143d80"
   },
   "Rk": 472,
-  "Player": "Naz Reid\\reidna01",
+  "Player": "Naz Reid",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/reidna01.jpg",
   "WS": "3.2",
-  "salary": "$705598",
+  "salary": "705598.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e8"
+    "$oid": "62850368cd0631716c143d81"
   },
   "Rk": 473,
-  "Player": "Nick RiCharlotte Hornetsrds\\riCharlotte Hornetsni01",
+  "Player": "Nick Richards",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/richani01.jpg",
   "WS": "1",
-  "salary": "$1290481",
-  "playerTeam": "CHO"
+  "salary": "1290481.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9e9"
+    "$oid": "62850368cd0631716c143d82"
   },
   "Rk": 474,
-  "Player": "Josh RiCharlotte Hornetsrdson\\riCharlotte Hornetsjo01",
+  "Player": "Josh Richardson",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/richajo01.jpg",
   "WS": "3.5",
-  "salary": "$666666",
+  "salary": "666666.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ea"
+    "$oid": "62850368cd0631716c143d83"
   },
   "Rk": 475,
-  "Player": "Austin Rivers\\riverau01",
+  "Player": "Austin Rivers",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/riverau01.jpg",
   "WS": "1.2",
-  "salary": "$663024",
+  "salary": "663024.00",
   "playerTeam": "Denver Nuggets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9eb"
+    "$oid": "62850368cd0631716c143d84"
   },
   "Rk": 476,
-  "Player": "Duncan Robinson\\robIndiana Pacersu01",
+  "Player": "Duncan Robinson",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/robindu01.jpg",
   "WS": "3.9",
-  "salary": "$2045094",
+  "salary": "2045094.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ec"
+    "$oid": "62850368cd0631716c143d85"
   },
   "Rk": 477,
-  "Player": "Justin Robinson\\robinju01",
+  "Player": "Justin Robinson",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/robinju01.jpg",
   "WS": "-0.3",
-  "salary": "$7622467",
-  "projSalary": "$333333",
+  "salary": "7622467.00",
+  "projSalary": "333333.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ed"
+    "$oid": "62850368cd0631716c143d86"
   },
   "Rk": 478,
-  "Player": "Mitchell Robinson\\robinmi01",
+  "Player": "Mitchell Robinson",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/robinmi01.jpg",
   "WS": "8.5",
-  "salary": "$1290481",
+  "salary": "1290481.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ee"
+    "$oid": "62850368cd0631716c143d87"
   },
   "Rk": 479,
-  "Player": "JereMiami Heath Robinson-Earl\\robinje02",
+  "Player": "Jeremiah Robinson-Earl",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/robinje02.jpg",
   "WS": "1.5",
-  "salary": "$606702",
+  "salary": "606702.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ef"
+    "$oid": "62850368cd0631716c143d88"
   },
   "Rk": 480,
-  "Player": "Isaiah Roby\\robyis01",
+  "Player": "Isaiah Roby",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/robyis01.jpg",
   "WS": "2.9",
-  "salary": "$2541217",
+  "salary": "2541217.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f0"
+    "$oid": "62850368cd0631716c143d89"
   },
   "Rk": 481,
-  "Player": "Rajon Rondo\\rondora01",
+  "Player": "Rajon Rondo",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/rondora01.jpg",
   "WS": "0.7",
-  "salary": "$11109327",
-  "projSalary": "$7827907",
+  "salary": "11109327.00",
+  "projSalary": "7827907.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f1"
+    "$oid": "62850368cd0631716c143d8a"
   },
   "Rk": 482,
-  "Player": "Derrick Rose\\rosede01",
+  "Player": "Derrick Rose",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/rosede01.jpg",
   "WS": "1.4",
-  "salary": "$586136",
+  "salary": "586136.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f2"
+    "$oid": "62850368cd0631716c143d8b"
   },
   "Rk": 483,
-  "Player": "Terrence Ross\\rosste01",
+  "Player": "Terrence Ross",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/rosste01.jpg",
   "WS": "0.3",
-  "salary": "$558345",
+  "salary": "558345.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f3"
+    "$oid": "62850368cd0631716c143d8c"
   },
   "Rk": 484,
-  "Player": "Terry Rozier\\roziete01",
+  "Player": "Terry Rozier",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/roziete01.jpg",
   "WS": "5.9",
-  "salary": "$527614",
-  "playerTeam": "CHO"
+  "salary": "527614.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f4"
+    "$oid": "62850368cd0631716c143d8d"
   },
   "Rk": 485,
-  "Player": "Ricky Rubio\\rubiori01",
+  "Player": "Ricky Rubio",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/rubiori01.jpg",
   "WS": "1.3",
-  "salary": "$10468119",
+  "salary": "10468119.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f5"
+    "$oid": "62850368cd0631716c143d8e"
   },
   "Rk": 486,
-  "Player": "D'Angelo Russell\\russeda01",
+  "Player": "D'Angelo Russell",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/russeda01.jpg",
   "WS": "4.4",
-  "salary": "$462629",
+  "salary": "462629.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f6"
+    "$oid": "62850368cd0631716c143d8f"
   },
   "Rk": 487,
-  "Player": "Matt Ryan\\ryanma01",
+  "Player": "Matt Ryan",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/ryanma01.jpg",
   "WS": "0",
-  "salary": "$4107149",
-  "projSalary": "$3925000",
+  "salary": "4107149.00",
+  "projSalary": "3925000.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f7"
+    "$oid": "62850368cd0631716c143d90"
   },
   "Rk": 488,
-  "Player": "Domantas Sabonis\\sabondo01",
+  "Player": "Domantas Sabonis",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sabondo01.jpg",
   "WS": "7.1",
-  "salary": "$377645",
+  "salary": "377645.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f8"
+    "$oid": "62850368cd0631716c143d91"
   },
   "Rk": 489,
-  "Player": "Olivier Sarr\\sarrol01",
+  "Player": "Olivier Sarr",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sarrol01.jpg",
   "WS": "1",
-  "salary": "$364533",
+  "salary": "364533.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9f9"
+    "$oid": "62850368cd0631716c143d92"
   },
   "Rk": 490,
-  "Player": "Tomáš SaToronto Raptorssanský\\saToronto Raptorssto01",
+  "Player": "Tomáš Satoranský",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/satorto01.jpg",
   "WS": "1",
-  "salary": "$350000",
+  "salary": "350000.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9fa"
+    "$oid": "62850368cd0631716c143d93"
   },
   "Rk": 491,
-  "Player": "Jordan SCharlotte Hornetskel\\sCharlotte Hornetskjo01",
+  "Player": "Jordan Schakel",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/schakjo01.jpg",
   "WS": "-0.1",
-  "salary": "$313737",
-  "projSalary": "$1563518",
+  "salary": "313737.00",
+  "projSalary": "1563518.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9fb"
+    "$oid": "62850368cd0631716c143d94"
   },
   "Rk": 492,
-  "Player": "Admiral Schofield\\schofad01",
+  "Player": "Admiral Schofield",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/schofad01.jpg",
   "WS": "0.3",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9fc"
+    "$oid": "62850368cd0631716c143d95"
   },
   "Rk": 493,
-  "Player": "Denver Nuggetsnis Schröder\\schrode01",
+  "Player": "Dennis Schröder",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/schrode01.jpg",
   "WS": "2.9",
-  "salary": "$292466",
-  "projSalary": "$1563518",
+  "salary": "292466.00",
+  "projSalary": "1563518.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9fd"
+    "$oid": "62850368cd0631716c143d96"
   },
   "Rk": 494,
-  "Player": "Tre Scott\\scotttr01",
+  "Player": "Tre Scott",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/scotttr01.jpg",
   "WS": "0",
-  "salary": "$290967",
-  "projSalary": "$1752638",
+  "salary": "290967.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9fe"
+    "$oid": "62850368cd0631716c143d97"
   },
   "Rk": 495,
-  "Player": "Jay Scrubb\\scrubja01",
+  "Player": "Jay Scrubb",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/scrubja01.jpg",
   "WS": "0",
-  "salary": "$276039",
+  "salary": "276039.00",
   "playerTeam": "Los Angeles Clippers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8d9ff"
+    "$oid": "62850368cd0631716c143d98"
   },
   "Rk": 496,
-  "Player": "Wayne SelDenver Nuggets\\seldewa01",
+  "Player": "Wayne Selden",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/seldewa01.jpg",
   "WS": "0",
-  "salary": "$260561",
-  "projSalary": "$1563518",
+  "salary": "260561.00",
+  "projSalary": "1563518.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da00"
+    "$oid": "62850368cd0631716c143d99"
   },
   "Rk": 497,
-  "Player": "Alperen Şengün\\sengual01",
+  "Player": "Alperen Şengün",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sengual01.jpg",
   "WS": "2.1",
-  "salary": "$8558",
+  "salary": "8558.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da01"
+    "$oid": "62850368cd0631716c143d9a"
   },
   "Rk": 498,
-  "Player": "Collin Sexton\\sextoco01",
+  "Player": "Collin Sexton",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sextoco01.jpg",
   "WS": "-0.1",
-  "salary": "$231062",
-  "projSalary": "$1752638",
+  "salary": "231062.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da02"
+    "$oid": "62850368cd0631716c143d9b"
   },
   "Rk": 499,
-  "Player": "Landry Shamet\\shamela01",
+  "Player": "Landry Shamet",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/shamela01.jpg",
   "WS": "2.6",
-  "salary": "$202068",
+  "salary": "202068.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da03"
+    "$oid": "62850368cd0631716c143d9c"
   },
   "Rk": 500,
-  "Player": "Day'Ron Sharpe\\sharpda01",
+  "Player": "Day'Ron Sharpe",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sharpda01.jpg",
   "WS": "1.2",
-  "salary": "$153488",
-  "playerTeam": "BRK"
+  "salary": "153488.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da04"
+    "$oid": "62850368cd0631716c143d9d"
   },
   "Rk": 501,
-  "Player": "Pascal Siakam\\siakapa01",
+  "Player": "Pascal Siakam",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/siakapa01.jpg",
   "WS": "8.1",
-  "salary": "$1366392",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "1366392.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da05"
+    "$oid": "62850368cd0631716c143d9e"
   },
   "Rk": 502,
-  "Player": "Chris Silva\\silvach01",
+  "Player": "Chris Silva",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/silvach01.jpg",
   "WS": "0.3",
-  "salary": "$1290481",
+  "salary": "1290481.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da06"
+    "$oid": "62850368cd0631716c143d9f"
   },
   "Rk": 503,
-  "Player": "Marko Simonovic\\simonma01",
+  "Player": "Marko Simonovic",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/simonma01.jpg",
   "WS": "0",
-  "salary": "$1290481",
+  "salary": "1290481.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da07"
+    "$oid": "62850368cd0631716c143da0"
   },
   "Rk": 504,
-  "Player": "Anfernee Simons\\simonan01",
+  "Player": "Anfernee Simons",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/simonan01.jpg",
   "WS": "1.9",
-  "salary": "$1290481",
+  "salary": "1290481.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da08"
+    "$oid": "62850368cd0631716c143da1"
   },
   "Rk": 505,
-  "Player": "Zavier Simpson\\simpsza01",
+  "Player": "Zavier Simpson",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/simpsza01.jpg",
   "WS": "-0.1",
-  "salary": "$924730",
+  "salary": "924730.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da09"
+    "$oid": "62850368cd0631716c143da2"
   },
   "Rk": 506,
-  "Player": "Jericho Sims\\simsje01",
+  "Player": "Jericho Sims",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/simsje01.jpg",
   "WS": "1.5",
-  "salary": "$924730",
+  "salary": "924730.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da0a"
+    "$oid": "62850368cd0631716c143da3"
   },
   "Rk": 507,
-  "Player": "Deividas Sirvydis\\sirvyde01",
+  "Player": "Deividas Sirvydis",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sirvyde01.jpg",
   "WS": "-0.1",
-  "salary": "$924730",
+  "salary": "924730.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da0b"
+    "$oid": "62850368cd0631716c143da4"
   },
   "Rk": 508,
-  "Player": "Javonte Smart\\smartja01",
+  "Player": "Javonte Smart",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/smartja01.jpg",
   "WS": "-0.2",
-  "salary": "$924730",
+  "salary": "924730.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da0c"
+    "$oid": "62850368cd0631716c143da5"
   },
   "Rk": 509,
-  "Player": "Marcus Smart\\smartma01",
+  "Player": "Marcus Smart",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/smartma01.jpg",
   "WS": "5.6",
-  "salary": "$276039",
+  "salary": "276039.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da0d"
+    "$oid": "62850368cd0631716c143da6"
   },
   "Rk": 510,
-  "Player": "Denver Nuggetsnis Smith Jr.\\smithde03",
+  "Player": "Dennis Smith Jr.",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/smithde03.jpg",
   "WS": "0.4",
-  "salary": "$276039",
+  "salary": "276039.00",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da0e"
+    "$oid": "62850368cd0631716c143da7"
   },
   "Rk": 511,
-  "Player": "Ish Smith\\smithis01",
+  "Player": "Ish Smith",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/smithis01.jpg",
   "WS": "0.5",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da0f"
+    "$oid": "62850368cd0631716c143da8"
   },
   "Rk": 512,
-  "Player": "Jalen Smith\\smithja04",
+  "Player": "Jalen Smith",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/smithja04.jpg",
   "WS": "2.8",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da10"
+    "$oid": "62850368cd0631716c143da9"
   },
   "Rk": 513,
-  "Player": "Xavier Sneed\\sneedxa01",
+  "Player": "Xavier Sneed",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sneedxa01.jpg",
   "WS": "0",
-  "salary": "$55208",
+  "salary": "55208.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da11"
+    "$oid": "62850368cd0631716c143daa"
   },
   "Rk": 514,
-  "Player": "Tony Snell\\snellto01",
+  "Player": "Tony Snell",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/snellto01.jpg",
   "WS": "0.4",
-  "salary": "$55208",
+  "salary": "55208.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da12"
+    "$oid": "62850368cd0631716c143dab"
   },
   "Rk": 515,
-  "Player": "JaDenver Nuggets Springer\\sprinja01",
+  "Player": "Jaden Springer",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sprinja01.jpg",
   "WS": "0",
-  "salary": "$55208",
+  "salary": "55208.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da13"
+    "$oid": "62850368cd0631716c143dac"
   },
   "Rk": 516,
-  "Player": "Cassius Stanley\\stanlca01",
+  "Player": "Cassius Stanley",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/stanlca01.jpg",
   "WS": "0.1",
-  "salary": "$55208",
+  "salary": "55208.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da14"
+    "$oid": "62850368cd0631716c143dad"
   },
   "Rk": 517,
-  "Player": "Nik Stauskas\\stausni01",
+  "Player": "Nik Stauskas",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/stausni01.jpg",
   "WS": "0.1",
-  "salary": "$276039",
+  "salary": "276039.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da15"
+    "$oid": "62850368cd0631716c143dae"
   },
   "Rk": 518,
-  "Player": "Lance Stephenson\\stephla01",
+  "Player": "Lance Stephenson",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/stephla01.jpg",
   "WS": "0.8",
-  "salary": "$924730",
+  "salary": "924730.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da16"
+    "$oid": "62850368cd0631716c143daf"
   },
   "Rk": 519,
-  "Player": "Lamar Stevens\\stevela01",
+  "Player": "Lamar Stevens",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/stevela01.jpg",
   "WS": "1.6",
-  "salary": "$1625991",
-  "projSalary": "$1752638",
+  "salary": "1625991.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da17"
+    "$oid": "62850368cd0631716c143db0"
   },
   "Rk": 520,
-  "Player": "Isaiah Stewart\\stewais01",
+  "Player": "Isaiah Stewart",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/stewais01.jpg",
   "WS": "3.4",
-  "salary": "$276039",
+  "salary": "276039.00",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da18"
+    "$oid": "62850368cd0631716c143db1"
   },
   "Rk": 521,
-  "Player": "Max Strus\\strusma01",
+  "Player": "Max Strus",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/strusma01.jpg",
   "WS": "3.6",
-  "salary": "$122741",
-  "projSalary": "$122741",
+  "salary": "122741.00",
+  "projSalary": "122741.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da19"
+    "$oid": "62850368cd0631716c143db2"
   },
   "Rk": 522,
-  "Player": "Jalen Suggs\\suggsja01",
+  "Player": "Jalen Suggs",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/suggsja01.jpg",
   "WS": "-1.6",
-  "salary": "$888616",
-  "projSalary": "$2351521",
+  "salary": "888616.00",
+  "projSalary": "2351521.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da1a"
+    "$oid": "62850368cd0631716c143db3"
   },
   "Rk": 523,
-  "Player": "Craig Sword\\swordcr01",
+  "Player": "Craig Sword",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/swordcr01.jpg",
   "WS": "0.1",
-  "salary": "$888616",
-  "projSalary": "$2351521",
+  "salary": "888616.00",
+  "projSalary": "2351521.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da1b"
+    "$oid": "62850368cd0631716c143db4"
   },
   "Rk": 524,
-  "Player": "Keifer Sykes\\sykeske01",
+  "Player": "Keifer Sykes",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/sykeske01.jpg",
   "WS": "-0.5",
-  "salary": "$888616",
-  "projSalary": "$2351521",
+  "salary": "888616.00",
+  "projSalary": "2351521.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da1c"
+    "$oid": "62850368cd0631716c143db5"
   },
   "Rk": 525,
-  "Player": "Jae'Sean Tate\\tateja01",
+  "Player": "Jae'Sean Tate",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/tateja01.jpg",
   "WS": "3",
-  "salary": "$888616",
-  "projSalary": "$2351521",
+  "salary": "888616.00",
+  "projSalary": "2351521.00",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da1d"
+    "$oid": "62850368cd0631716c143db6"
   },
   "Rk": 526,
-  "Player": "Jayson Tatum\\tatumja01",
+  "Player": "Jayson Tatum",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/tatumja01.jpg",
   "WS": "9.6",
-  "salary": "$958529",
-  "projSalary": "$2193920",
+  "salary": "958529.00",
+  "projSalary": "2193920.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da1e"
+    "$oid": "62850368cd0631716c143db7"
   },
   "Rk": 527,
-  "Player": "Terry Taylor\\taylote01",
+  "Player": "Terry Taylor",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/taylote01.jpg",
   "WS": "2.4",
-  "salary": "$958529",
-  "projSalary": "$2193920",
+  "salary": "958529.00",
+  "projSalary": "2193920.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da1f"
+    "$oid": "62850368cd0631716c143db8"
   },
   "Rk": 528,
-  "Player": "Garrett Temple\\templga01",
+  "Player": "Garrett Temple",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/templga01.jpg",
   "WS": "0.8",
-  "salary": "$958529",
-  "projSalary": "$2193920",
-  "playerTeam": "NOP"
+  "salary": "958529.00",
+  "projSalary": "2193920.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da20"
+    "$oid": "62850368cd0631716c143db9"
   },
   "Rk": 529,
-  "Player": "Emanuel Terry\\terryem01",
+  "Player": "Emanuel Terry",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/terryem01.jpg",
   "WS": "-0.1",
-  "salary": "$2045094",
+  "salary": "2045094.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da21"
+    "$oid": "62850368cd0631716c143dba"
   },
   "Rk": 530,
-  "Player": "Tyrell Terry\\terryty01",
+  "Player": "Tyrell Terry",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/terryty01.jpg",
   "WS": "0",
-  "salary": "$2045094",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "2045094.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da22"
+    "$oid": "62850368cd0631716c143dbb"
   },
   "Rk": 531,
-  "Player": "Jon Teske\\teskejo01",
+  "Player": "Jon Teske",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/teskejo01.jpg",
   "WS": "0",
-  "salary": "$2045094",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "2045094.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da23"
+    "$oid": "62850368cd0631716c143dbc"
   },
   "Rk": 532,
-  "Player": "Daniel Theis\\theisda01",
+  "Player": "Daniel Theis",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/theisda01.jpg",
   "WS": "1.9",
-  "salary": "$2045094",
+  "salary": "2045094.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da24"
+    "$oid": "62850368cd0631716c143dbd"
   },
   "Rk": 533,
-  "Player": "Brodric Thomas\\thomabr01",
+  "Player": "Brodric Thomas",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/thomabr01.jpg",
   "WS": "0.1",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da25"
+    "$oid": "62850368cd0631716c143dbe"
   },
   "Rk": 534,
-  "Player": "Cam Thomas\\thomaca02",
+  "Player": "Cam Thomas",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/thomaca02.jpg",
   "WS": "0.8",
-  "salary": "$586136",
-  "playerTeam": "BRK"
+  "salary": "586136.00",
+  "playerTeam": "Brooklyn Nets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da26"
+    "$oid": "62850368cd0631716c143dbf"
   },
   "Rk": 535,
-  "Player": "Isaiah Thomas\\thomais02",
+  "Player": "Isaiah Thomas",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/thomais02.jpg",
   "WS": "0.2",
-  "salary": "$586136",
+  "salary": "586136.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da27"
+    "$oid": "62850368cd0631716c143dc0"
   },
   "Rk": 536,
-  "Player": "Matt Thomas\\thomama02",
+  "Player": "Matt Thomas",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/thomama02.jpg",
   "WS": "0.6",
-  "salary": "$606702",
+  "salary": "606702.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da28"
+    "$oid": "62850368cd0631716c143dc1"
   },
   "Rk": 537,
-  "Player": "Klay Thompson\\thompkl01",
+  "Player": "Klay Thompson",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/thompkl01.jpg",
   "WS": "1.8",
-  "salary": "$606702",
+  "salary": "606702.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da29"
+    "$oid": "62850368cd0631716c143dc2"
   },
   "Rk": 538,
-  "Player": "Tristan Thompson\\thomptr01",
+  "Player": "Tristan Thompson",
   "age": 30,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/thomptr01.jpg",
   "WS": "1.6",
-  "salary": "$1090007",
+  "salary": "1090007.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da2a"
+    "$oid": "62850368cd0631716c143dc3"
   },
   "Rk": 539,
-  "Player": "JT Thor\\thorjt01",
+  "Player": "JT Thor",
   "age": 19,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/thorjt01.jpg",
   "WS": "0.3",
-  "salary": "$1090007",
-  "playerTeam": "CHO"
+  "salary": "1090007.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da2b"
+    "$oid": "62850368cd0631716c143dc4"
   },
   "Rk": 540,
-  "Player": "Matisse Thybulle\\thybuma01",
+  "Player": "Matisse Thybulle",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/thybuma01.jpg",
   "WS": "3.7",
-  "salary": "$1068288",
+  "salary": "1068288.00",
   "playerTeam": "Philadelphia 76ers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da2c"
+    "$oid": "62850368cd0631716c143dc5"
   },
   "Rk": 541,
-  "Player": "Killian Tillie\\tilliki02",
+  "Player": "Killian Tillie",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/tilliki02.jpg",
   "WS": "0.6",
-  "salary": "$100000",
-  "projSalary": "$1752638",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "100000.00",
+  "projSalary": "1752638.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da2d"
+    "$oid": "62850368cd0631716c143dc6"
   },
   "Rk": 542,
-  "Player": "Xavier Tillman Sr.\\tillmxa01",
+  "Player": "Xavier Tillman Sr.",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/tillmxa01.jpg",
   "WS": "1.8",
-  "salary": "$1762796",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "1762796.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da2e"
+    "$oid": "62850368cd0631716c143dc7"
   },
   "Rk": 543,
-  "Player": "Isaiah Todd\\toddis01",
+  "Player": "Isaiah Todd",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/toddis01.jpg",
   "WS": "-0.2",
-  "salary": "$1762796",
+  "salary": "1762796.00",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da2f"
+    "$oid": "62850368cd0631716c143dc8"
   },
   "Rk": 544,
-  "Player": "Obi Toppin\\toppiob01",
+  "Player": "Obi Toppin",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/toppiob01.jpg",
   "WS": "3.9",
-  "salary": "$1762796",
+  "salary": "1762796.00",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da30"
+    "$oid": "62850368cd0631716c143dc9"
   },
   "Rk": 545,
-  "Player": "Juan Toscano-Anderson\\toscaju01",
+  "Player": "Juan Toscano-Anderson",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/toscaju01.jpg",
   "WS": "2",
-  "salary": "$1762796",
+  "salary": "1762796.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da31"
+    "$oid": "62850368cd0631716c143dca"
   },
   "Rk": 546,
-  "Player": "Karl-Anthony Towns\\townska01",
+  "Player": "Karl-Anthony Towns",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/townska01.jpg",
   "WS": "10.3",
-  "salary": "$1762796",
+  "salary": "1762796.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da32"
+    "$oid": "62850368cd0631716c143dcb"
   },
   "Rk": 547,
-  "Player": "Gary Trent Jr.\\trentga02",
+  "Player": "Gary Trent Jr.",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/trentga02.jpg",
   "WS": "5.6",
-  "salary": "$705598",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "705598.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da33"
+    "$oid": "62850368cd0631716c143dcc"
   },
   "Rk": 548,
-  "Player": "P.J. Tucker\\tuckepj01",
+  "Player": "P.J. Tucker",
   "age": 36,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/tuckepj01.jpg",
   "WS": "5",
-  "salary": "$705598",
+  "salary": "705598.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da34"
+    "$oid": "62850368cd0631716c143dcd"
   },
   "Rk": 549,
-  "Player": "Rayjon Tucker\\tuckera01",
+  "Player": "Rayjon Tucker",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/tuckera01.jpg",
   "WS": "0.4",
-  "salary": "$29814",
-  "projSalary": "$1878720",
+  "salary": "29814.00",
+  "projSalary": "1878720.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da35"
+    "$oid": "62850368cd0631716c143dce"
   },
   "Rk": 550,
-  "Player": "Myles Turner\\turnemy01",
+  "Player": "Myles Turner",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/turnemy01.jpg",
   "WS": "3.1",
-  "salary": "$29814",
-  "projSalary": "$1878720",
+  "salary": "29814.00",
+  "projSalary": "1878720.00",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da36"
+    "$oid": "62850368cd0631716c143dcf"
   },
   "Rk": 551,
-  "Player": "Jonas Valančiūnas\\valanjo01",
+  "Player": "Jonas Valančiūnas",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/valanjo01.jpg",
   "WS": "7.3",
-  "playerTeam": "NOP"
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da37"
+    "$oid": "62850368cd0631716c143dd0"
   },
   "Rk": 552,
-  "Player": "Denver Nuggetszel Valentine\\valende01",
+  "Player": "Denzel Valentine",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/valende01.jpg",
   "WS": "0.2",
-  "salary": "$705598",
+  "salary": "705598.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da38"
+    "$oid": "62850368cd0631716c143dd1"
   },
   "Rk": 553,
-  "Player": "Jarred Vanderbilt\\vandeja01",
+  "Player": "Jarred Vanderbilt",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/vandeja01.jpg",
   "WS": "6",
-  "salary": "$705598",
+  "salary": "705598.00",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da39"
+    "$oid": "62850368cd0631716c143dd2"
   },
   "Rk": 554,
-  "Player": "Fred VanVleet\\vanvlfr01",
+  "Player": "Fred VanVleet",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/vanvlfr01.jpg",
   "WS": "6.7",
-  "salary": "$29814",
-  "projSalary": "$1878720",
-  "playerTeam": "Toronto Raptorss"
+  "salary": "29814.00",
+  "projSalary": "1878720.00",
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da3a"
+    "$oid": "62850368cd0631716c143dd3"
   },
   "Rk": 555,
-  "Player": "Devin Vassell\\vassede01",
+  "Player": "Devin Vassell",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/vassede01.jpg",
   "WS": "3.3",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da3b"
+    "$oid": "62850368cd0631716c143dd4"
   },
   "Rk": 556,
-  "Player": "Gabe Vincent\\vincega01",
+  "Player": "Gabe Vincent",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/vincega01.jpg",
   "WS": "2.5",
-  "salary": "$29814",
-  "projSalary": "$1878720",
+  "salary": "29814.00",
+  "projSalary": "1878720.00",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da3c"
+    "$oid": "62850368cd0631716c143dd5"
   },
   "Rk": 557,
-  "Player": "Nikola Vučević\\vucevni01",
+  "Player": "Nikola Vučević",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/vucevni01.jpg",
   "WS": "4.5",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da3d"
+    "$oid": "62850368cd0631716c143dd6"
   },
   "Rk": 558,
-  "Player": "Dean Wade\\wadede01",
+  "Player": "Dean Wade",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wadede01.jpg",
   "WS": "2.3",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da3e"
+    "$oid": "62850368cd0631716c143dd7"
   },
   "Rk": 559,
-  "Player": "Franz Wagner\\wagnefr01",
+  "Player": "Franz Wagner",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wagnefr01.jpg",
   "WS": "4",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da3f"
+    "$oid": "62850368cd0631716c143dd8"
   },
   "Rk": 560,
-  "Player": "Moritz Wagner\\wagnemo01",
+  "Player": "Moritz Wagner",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wagnemo01.jpg",
   "WS": "2.8",
-  "salary": "$1720779",
+  "salary": "1720779.00",
   "playerTeam": "Orlando Magic"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da40"
+    "$oid": "62850368cd0631716c143dd9"
   },
   "Rk": 561,
-  "Player": "Ish Wainright\\wainris01",
+  "Player": "Ish Wainright",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wainris01.jpg",
   "WS": "0.6",
-  "salary": "$1720779",
+  "salary": "1720779.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da41"
+    "$oid": "62850368cd0631716c143dda"
   },
   "Rk": 562,
-  "Player": "Kemba Walker\\walkeke02",
+  "Player": "Kemba Walker",
   "age": 31,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/walkeke02.jpg",
   "WS": "1.8",
   "playerTeam": "New York Knicks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da42"
+    "$oid": "62850368cd0631716c143ddb"
   },
   "Rk": 563,
-  "Player": "Lonnie Walker IV\\walkelo01",
+  "Player": "Lonnie Walker IV",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/walkelo01.jpg",
   "WS": "1.2",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da43"
+    "$oid": "62850368cd0631716c143ddc"
   },
   "Rk": 564,
-  "Player": "M.J. Walker\\walkemj01",
+  "Player": "M.J. Walker",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/walkemj01.jpg",
   "WS": "0",
-  "salary": "$19186",
-  "projSalary": "$1815677",
+  "salary": "19186.00",
+  "projSalary": "1815677.00",
   "playerTeam": "Phoenix Suns"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da44"
+    "$oid": "62850368cd0631716c143ddd"
   },
   "Rk": 565,
-  "Player": "Tyrone WalLos Angeles Clipperse\\wallaty01",
+  "Player": "Tyrone Wallace",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wallaty01.jpg",
   "WS": "-0.1",
-  "salary": "$19186",
-  "projSalary": "$1815677",
-  "playerTeam": "NOP"
+  "salary": "19186.00",
+  "projSalary": "1815677.00",
+  "playerTeam": "New Orleans Pelicans"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da45"
+    "$oid": "62850368cd0631716c143dde"
   },
   "Rk": 566,
-  "Player": "Derrick Walton\\waltode01",
+  "Player": "Derrick Walton",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/waltode01.jpg",
   "WS": "-0.2",
   "playerTeam": "Detroit Pistons"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da46"
+    "$oid": "62850368cd0631716c143ddf"
   },
   "Rk": 567,
-  "Player": "Brad Wanamaker\\wanambr01",
+  "Player": "Brad Wanamaker",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wanambr01.jpg",
   "WS": "0",
-  "salary": "$850331",
+  "salary": "850331.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da47"
+    "$oid": "62850368cd0631716c143de0"
   },
   "Rk": 568,
-  "Player": "Duane Washington Wizardshington Jr.\\Washington Wizardshidu02",
+  "Player": "Duane Washington Jr.",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/washidu02.jpg",
   "WS": "0",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da48"
+    "$oid": "62850368cd0631716c143de1"
   },
   "Rk": 569,
-  "Player": "P.J. Washington Wizardshington\\Washington Wizardshipj01",
+  "Player": "P.J. Washington",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/washipj01.jpg",
   "WS": "3.4",
-  "salary": "$28779",
-  "projSalary": "$1815677",
-  "playerTeam": "CHO"
+  "salary": "28779.00",
+  "projSalary": "1815677.00",
+  "playerTeam": "Charlotte Hornets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da49"
+    "$oid": "62850368cd0631716c143de2"
   },
   "Rk": 570,
-  "Player": "YUtah Jazz Watanabe\\watanyu01",
+  "Player": "YUtah Jazz Watanabe",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/watanyu01.jpg",
   "WS": "0.7",
-  "playerTeam": "Toronto Raptorss"
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da4a"
+    "$oid": "62850368cd0631716c143de3"
   },
   "Rk": 571,
-  "Player": "LIndiana Pacersy Waters III\\waterli01",
+  "Player": "LIndiana Pacersy Waters III",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/waterli01.jpg",
   "WS": "0.8",
-  "salary": "$28779",
-  "projSalary": "$1815677",
+  "salary": "28779.00",
+  "projSalary": "1815677.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da4b"
+    "$oid": "62850368cd0631716c143de4"
   },
   "Rk": 572,
-  "Player": "Tremont Waters\\watertr01",
+  "Player": "Tremont Waters",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/watertr01.jpg",
   "WS": "0",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da4c"
+    "$oid": "62850368cd0631716c143de5"
   },
   "Rk": 573,
-  "Player": "Trendon Watford\\watfotr01",
+  "Player": "Trendon Watford",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/watfotr01.jpg",
   "WS": "1.9",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da4d"
+    "$oid": "62850368cd0631716c143de6"
   },
   "Rk": 574,
-  "Player": "Paul Watson\\watsopa01",
+  "Player": "Paul Watson",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/watsopa01.jpg",
   "WS": "0",
-  "salary": "$92857",
-  "projSalary": "$92857",
+  "salary": "92857.00",
+  "projSalary": "92857.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da4e"
+    "$oid": "62850368cd0631716c143de7"
   },
   "Rk": 575,
-  "Player": "Quinndary Weatherspoon\\weathqu01",
+  "Player": "Quinndary Weatherspoon",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/weathqu01.jpg",
   "WS": "0.2",
-  "salary": "$290967",
-  "projSalary": "$1752638",
+  "salary": "290967.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da4f"
+    "$oid": "62850368cd0631716c143de8"
   },
   "Rk": 576,
-  "Player": "Russell Westbrook\\westbru01",
+  "Player": "Russell Westbrook",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/westbru01.jpg",
   "WS": "1.7",
-  "salary": "$290967",
-  "projSalary": "$1752638",
+  "salary": "290967.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Los Angeles Lakers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da50"
+    "$oid": "62850368cd0631716c143de9"
   },
   "Rk": 577,
-  "Player": "Coby White\\whiteco01",
+  "Player": "Coby White",
   "age": 21,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/whiteco01.jpg",
   "WS": "2.4",
-  "salary": "$290967",
-  "projSalary": "$1752638",
+  "salary": "290967.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da51"
+    "$oid": "62850368cd0631716c143dea"
   },
   "Rk": 578,
-  "Player": "Derrick White\\whitede01",
+  "Player": "Derrick White",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/whitede01.jpg",
   "WS": "5.1",
-  "salary": "$231062",
-  "projSalary": "$1752638",
+  "salary": "231062.00",
+  "projSalary": "1752638.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da52"
+    "$oid": "62850368cd0631716c143deb"
   },
   "Rk": 579,
-  "Player": "Hassan Whiteside\\whiteha01",
+  "Player": "Hassan Whiteside",
   "age": 32,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/whiteha01.jpg",
   "WS": "5.8",
-  "salary": "$231062",
-  "projSalary": "$1752638",
+  "salary": "231062.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Utah Jazz"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da53"
+    "$oid": "62850368cd0631716c143dec"
   },
   "Rk": 580,
-  "Player": "Joe Wieskamp\\wieskjo01",
+  "Player": "Joe Wieskamp",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wieskjo01.jpg",
   "WS": "0.1",
-  "salary": "$1625991",
-  "projSalary": "$1752638",
+  "salary": "1625991.00",
+  "projSalary": "1752638.00",
   "playerTeam": "San Antonio Spurs"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da54"
+    "$oid": "62850368cd0631716c143ded"
   },
   "Rk": 581,
-  "Player": "Aaron Wiggins\\wiggiaa01",
+  "Player": "Aaron Wiggins",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wiggiaa01.jpg",
   "WS": "1.2",
-  "salary": "$1625991",
-  "projSalary": "$1752638",
+  "salary": "1625991.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da55"
+    "$oid": "62850368cd0631716c143dee"
   },
   "Rk": 582,
-  "Player": "Andrew Wiggins\\wiggian01",
+  "Player": "Andrew Wiggins",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wiggian01.jpg",
   "WS": "5.1",
-  "salary": "$100000",
-  "projSalary": "$1752638",
+  "salary": "100000.00",
+  "projSalary": "1752638.00",
   "playerTeam": "Golden State Warriors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da56"
+    "$oid": "62850368cd0631716c143def"
   },
   "Rk": 583,
-  "Player": "LIndiana Pacersell Wigginton\\wiggili01",
+  "Player": "Lindell Wigginton",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wiggili01.jpg",
   "WS": "0.2",
   "playerTeam": "Milwaukee Bucks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da57"
+    "$oid": "62850368cd0631716c143df0"
   },
   "Rk": 584,
-  "Player": "Brandon Williams\\willibr03",
+  "Player": "Brandon Williams",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/willibr03.jpg",
   "WS": "-0.5",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da58"
+    "$oid": "62850368cd0631716c143df1"
   },
   "Rk": 585,
-  "Player": "Grant Williams\\willigr01",
+  "Player": "Grant Williams",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/willigr01.jpg",
   "WS": "5.1",
-  "salary": "$1517981",
-  "projSalary": "$1782621",
+  "salary": "1517981.00",
+  "projSalary": "1782621.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da59"
+    "$oid": "62850368cd0631716c143df2"
   },
   "Rk": 586,
-  "Player": "Kenrich Williams\\willike04",
+  "Player": "Kenrich Williams",
   "age": 27,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/willike04.jpg",
   "WS": "1.8",
   "playerTeam": "Oklahoma City Thunder"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da5a"
+    "$oid": "62850368cd0631716c143df3"
   },
   "Rk": 587,
-  "Player": "Lou Williams\\willilo02",
+  "Player": "Lou Williams",
   "age": 35,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/willilo02.jpg",
   "WS": "0.6",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da5b"
+    "$oid": "62850368cd0631716c143df4"
   },
   "Rk": 588,
-  "Player": "Patrick Williams\\willipa01",
+  "Player": "Patrick Williams",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/willipa01.jpg",
   "WS": "0.9",
-  "salary": "$76744",
-  "projSalary": "$1815677",
+  "salary": "76744.00",
+  "projSalary": "1815677.00",
   "playerTeam": "Chicago Bulls"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da5c"
+    "$oid": "62850368cd0631716c143df5"
   },
   "Rk": 589,
-  "Player": "Robert Williams\\williro04",
+  "Player": "Robert Williams",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/williro04.jpg",
   "WS": "9.9",
-  "salary": "$58493",
+  "salary": "58493.00",
   "playerTeam": "Boston Celtics"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da5d"
+    "$oid": "62850368cd0631716c143df6"
   },
   "Rk": 590,
-  "Player": "Ziaire Williams\\willizi02",
+  "Player": "Ziaire Williams",
   "age": 20,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/willizi02.jpg",
   "WS": "2.2",
-  "salary": "$55208",
-  "playerTeam": "MemPhiladelphia 76erss Grizzlies"
+  "salary": "55208.00",
+  "playerTeam": "Memphis Grizzlies"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da5e"
+    "$oid": "62850368cd0631716c143df7"
   },
   "Rk": 591,
-  "Player": "D.J. Wilson\\wilsodj01",
+  "Player": "D.J. Wilson",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wilsodj01.jpg",
   "WS": "0.4",
-  "playerTeam": "Toronto Raptorss"
+  "playerTeam": "Toronto Raptors"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da5f"
+    "$oid": "62850368cd0631716c143df8"
   },
   "Rk": 592,
-  "Player": "Dylan WIndiana Pacersler\\wIndiana Pacersldy01",
+  "Player": "Dylan Windler",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/windldy01.jpg",
   "WS": "0.8",
   "playerTeam": "Cleveland Cavaliers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da60"
+    "$oid": "62850368cd0631716c143df9"
   },
   "Rk": 593,
-  "Player": "Justise Winslow\\winslju01",
+  "Player": "Justise Winslow",
   "age": 25,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/winslju01.jpg",
   "WS": "0.8",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da61"
+    "$oid": "62850368cd0631716c143dfa"
   },
   "Rk": 594,
-  "Player": "Cassius Winston\\winstca01",
+  "Player": "Cassius Winston",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/winstca01.jpg",
   "WS": "0",
   "playerTeam": "Washington Wizards"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da62"
+    "$oid": "62850368cd0631716c143dfb"
   },
   "Rk": 595,
-  "Player": "Christian Wood\\woodch01",
+  "Player": "Christian Wood",
   "age": 26,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/woodch01.jpg",
   "WS": "4.9",
   "playerTeam": "Houston Rockets"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da63"
+    "$oid": "62850368cd0631716c143dfc"
   },
   "Rk": 596,
-  "Player": "Robert Woodard II\\woodaro01",
+  "Player": "Robert Woodard II",
   "age": 22,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/woodaro01.jpg",
   "WS": "-0.1",
   "playerTeam": "Sacramento Kings"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da64"
+    "$oid": "62850368cd0631716c143dfd"
   },
   "Rk": 597,
-  "Player": "Delon Wright\\wrighde01",
+  "Player": "Delon Wright",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wrighde01.jpg",
   "WS": "3.6",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da65"
+    "$oid": "62850368cd0631716c143dfe"
   },
   "Rk": 598,
-  "Player": "McKinley Wright IV\\wrighmc01",
+  "Player": "McKinley Wright IV",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wrighmc01.jpg",
   "WS": "0",
   "playerTeam": "Minnesota Timberwolves"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da66"
+    "$oid": "62850368cd0631716c143dff"
   },
   "Rk": 599,
-  "Player": "Moses Wright\\wrighmo01",
+  "Player": "Moses Wright",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/wrighmo01.jpg",
   "WS": "0.1",
-  "salary": "$462629",
+  "salary": "462629.00",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da67"
+    "$oid": "62850368cd0631716c143e00"
   },
   "Rk": 600,
-  "Player": "Gabe York\\yorkga01",
+  "Player": "Gabe York",
   "age": 28,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/yorkga01.jpg",
   "WS": "0",
   "playerTeam": "Indiana Pacers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da68"
+    "$oid": "62850368cd0631716c143e01"
   },
   "Rk": 601,
-  "Player": "Thaddeus Young\\youngth01",
+  "Player": "Thaddeus Young",
   "age": 33,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/youngth01.jpg",
   "WS": "2.2",
   "playerTeam": "TOT"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da69"
+    "$oid": "62850368cd0631716c143e02"
   },
   "Rk": 602,
-  "Player": "Trae Young\\youngtr01",
+  "Player": "Trae Young",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/youngtr01.jpg",
   "WS": "10",
   "playerTeam": "Atlanta Hawks"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da6a"
+    "$oid": "62850368cd0631716c143e03"
   },
   "Rk": 603,
-  "Player": "Omer Yurtseven\\yurtsom01",
+  "Player": "Omer Yurtseven",
   "age": 23,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/yurtsom01.jpg",
   "WS": "2.1",
   "playerTeam": "Miami Heat"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da6b"
+    "$oid": "62850368cd0631716c143e04"
   },
   "Rk": 604,
-  "Player": "Cody Zeller\\zelleco01",
+  "Player": "Cody Zeller",
   "age": 29,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/zelleco01.jpg",
   "WS": "1.1",
   "playerTeam": "Portland Trail Blazers"
 },{
   "_id": {
-    "$oid": "6278b895318b04fff3e8da6c"
+    "$oid": "62850368cd0631716c143e05"
   },
   "Rk": 605,
-  "Player": "Ivica Zubac\\zubaciv01",
+  "Player": "Ivica Zubac",
   "age": 24,
+  "playerPicture": "https://www.basketball-reference.com/req/202106291/images/players/zubaciv01.jpg",
   "WS": "7.2",
   "playerTeam": "Los Angeles Clippers"
 }]


### PR DESCRIPTION
With this new update to the players' table, you are able to use the URLs under playerPicture column and get the profile picture for each of the NBA players.